### PR TITLE
feat: #18 모임 관련 Entity, Repository 수정

### DIFF
--- a/src/main/java/com/bookjuk/BookJukApplication.java
+++ b/src/main/java/com/bookjuk/BookJukApplication.java
@@ -5,10 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 
-@SpringBootApplication(exclude = {
-        DataSourceAutoConfiguration.class,
-        HibernateJpaAutoConfiguration.class
-})
+@SpringBootApplication
 public class BookJukApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/bookjuk/domain/meeting/Meeting.java
+++ b/src/main/java/com/bookjuk/domain/meeting/Meeting.java
@@ -1,5 +1,6 @@
 package com.bookjuk.domain.meeting;
 
+import com.bookjuk.domain.participant.MeetingParticipant;
 import com.bookjuk.domain.user.User;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
@@ -9,6 +10,8 @@ import org.hibernate.annotations.Comment;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Meeting 클래스는 독서 모임에 대한 정보를 나타내는 엔티티로, 모임의 기본 정보와 관련 데이터들을 포함한다.
@@ -53,6 +56,10 @@ public class Meeting {
     @JoinColumn(name = "host_id", nullable = false)
     @Comment("방장(주최자)의 user_id")
     private User host; // host_id 컬럼을 User 객체로 매핑합니다.
+
+    // 중간 엔티티 기준 1:N
+    @OneToMany(mappedBy = "meeting", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MeetingParticipant> meetingParticipants = new ArrayList<>();
 
     @Column(name = "title", nullable = false, length = 255)
     @Comment("모임 제목")
@@ -115,9 +122,14 @@ public class Meeting {
     @Comment("모임 정보 수정 시점")
     private LocalDateTime updatedAt;
 
+    // 모임 제목 변경 도메인 메서드, MeetingRepositoryTest 전용
+    public void changeTitle(String newTitle) {
+        this.title = newTitle;
+    }
+
     // 빌더 패턴을 사용한 생성자
     @Builder
-    public Meeting(User host, String title, String description, String imageUrl, String bookTitle, String bookAuthor, String genre, LocalDateTime meetingTime, String region, String city, String detailAddress, Integer maxParticipants, MeetingStatus status) {
+    public Meeting(User host, String title, String description, String imageUrl, String bookTitle, String bookAuthor, String genre, LocalDateTime meetingTime, String region, String city, String detailAddress, Integer maxParticipants, MeetingStatus meetingStatus) {
         this.host = host;
         this.title = title;
         this.description = description;
@@ -130,7 +142,7 @@ public class Meeting {
         this.city = city;
         this.detailAddress = detailAddress;
         this.maxParticipants = maxParticipants;
-        this.meetingStatus = status;
+        this.meetingStatus = meetingStatus;
     }
 
 }

--- a/src/main/java/com/bookjuk/domain/meeting/Meeting.java
+++ b/src/main/java/com/bookjuk/domain/meeting/Meeting.java
@@ -106,7 +106,7 @@ public class Meeting {
 
     // 빌더 패턴을 사용한 생성자
     @Builder
-    public Meeting(User host, String title, String description, String imageUrl, String bookTitle, String bookAuthor, String genre, LocalDateTime meetingTime, String location, int maxParticipants, String status) {
+    public Meeting(User host, String title, String description, String imageUrl, String bookTitle, String bookAuthor, String genre, LocalDateTime meetingTime, String location, Integer maxParticipants, String status) {
         this.host = host;
         this.title = title;
         this.description = description;

--- a/src/main/java/com/bookjuk/domain/meeting/Meeting.java
+++ b/src/main/java/com/bookjuk/domain/meeting/Meeting.java
@@ -2,6 +2,7 @@ package com.bookjuk.domain.meeting;
 
 import com.bookjuk.domain.user.User;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
 import lombok.AccessLevel;
 import lombok.*;
 import org.hibernate.annotations.Comment;
@@ -81,12 +82,22 @@ public class Meeting {
     @Comment("모임 시간")
     private LocalDateTime meetingTime;
 
-    @Column(name = "location", nullable = false, length = 255)
-    @Comment("모임 장소")
-    private String location;
+    // 주소 정규화
+    @Column(name = "region", nullable = false, length = 20)
+    @Comment("시/도")
+    private String region;
+
+    @Column(name = "city", nullable = false, length = 30)
+    @Comment("시/구/군")
+    private String city;
+
+    @Column(name = "detail_address", length = 255)
+    @Comment("상세주소(선택)")
+    private String detailAddress;
 
     @Column(name = "max_participants", nullable = false)
     @Comment("최대 참여 인원")
+    @Max(value = 10)
     private Integer maxParticipants;
 
     @Column(name = "status", nullable = false, length = 20)
@@ -106,7 +117,7 @@ public class Meeting {
 
     // 빌더 패턴을 사용한 생성자
     @Builder
-    public Meeting(User host, String title, String description, String imageUrl, String bookTitle, String bookAuthor, String genre, LocalDateTime meetingTime, String location, Integer maxParticipants, String status) {
+    public Meeting(User host, String title, String description, String imageUrl, String bookTitle, String bookAuthor, String genre, LocalDateTime meetingTime, String region, String city, String detailAddress, Integer maxParticipants, MeetingStatus status) {
         this.host = host;
         this.title = title;
         this.description = description;
@@ -115,9 +126,11 @@ public class Meeting {
         this.bookAuthor = bookAuthor;
         this.genre = genre;
         this.meetingTime = meetingTime;
-        this.location = location;
+        this.region = region;
+        this.city = city;
+        this.detailAddress = detailAddress;
         this.maxParticipants = maxParticipants;
-        this.meetingStatus = meetingStatus;
+        this.meetingStatus = status;
     }
 
 }

--- a/src/main/java/com/bookjuk/domain/meeting/Meeting.java
+++ b/src/main/java/com/bookjuk/domain/meeting/Meeting.java
@@ -1,4 +1,123 @@
 package com.bookjuk.domain.meeting;
 
+import com.bookjuk.domain.user.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.*;
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+import java.time.LocalDateTime;
+
+/**
+ * Meeting 클래스는 독서 모임에 대한 정보를 나타내는 엔티티로, 모임의 기본 정보와 관련 데이터들을 포함한다.
+ * 이 클래스는 JPA를 사용하여 데이터베이스와 매핑되고, 모임과 관련된 다양한 속성을 제공한다.
+ *
+ * 주요 속성:
+ * - id: 모임의 고유 식별자
+ * - user: 모임의 방장(주최자) 정보를 포함하는 User 엔티티와의 연관 관계
+ * - title: 모임의 제목
+ * - description: 모임의 상세 설명
+ * - imageUrl: 대표 이미지 URL
+ * - bookTitle: 모임에서 선정한 도서의 제목
+ * - bookAuthor: 모임에서 선정한 도서의 저자
+ * - genre: 모임 장르(도서 장르 등)
+ * - meetingTime: 모임 시간
+ * - location: 모임 장소
+ * - maxParticipants: 모임 최대 참여 인원
+ * - status: 모임 상태 (RECRUITING, COMPLETED, CANCELLED)
+ * - createdAt: 모임 생성 시간 (자동 생성)
+ * - updatedAt: 모임 정보 수정 시간 (자동 업데이트)
+ *
+ * 이 클래스는 lombok 라이브러리를 활용하여 getter 메서드, equals, hashCode, toString 메서드를 자동으로 생성한다.
+ * 불변성을 유지하기 위해 기본 생성자는 protected로 제한되어 있으며, 빌더 패턴을 지원하도록 설계될 수 있다.
+ */
+
+@Entity
+@Table(name = "meeting")
+@Getter
+@ToString(exclude = {"host"})   //  Meeting 엔티티는 User를 참조하고 있으므로, host 필드를 exclude
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Meeting {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "meeting_id")
+    @Comment("모임 고유 식별자")
+    private Long id;
+
+    // User 엔티티와 N대1 관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "host_id", nullable = false)
+    @Comment("방장(주최자)의 user_id")
+    private User host; // host_id 컬럼을 User 객체로 매핑합니다.
+
+    @Column(name = "title", nullable = false, length = 255)
+    @Comment("모임 제목")
+    private String title;
+
+    @Column(name = "description", columnDefinition = "TEXT")
+    @Comment("모임 상세 설명")
+    private String description;
+
+    @Column(name = "image_url", length = 255)
+    @Comment("모임 대표 이미지 URL")
+    private String imageUrl;
+
+    @Column(name = "book_title", nullable = false, length = 255)
+    @Comment("선정 도서 제목")
+    private String bookTitle;
+
+    @Column(name = "book_author", nullable = false, length = 100)
+    @Comment("선정 도서 저자")
+    private String bookAuthor;
+
+    @Column(name = "genre", length = 100)
+    @Comment("모임 장르")
+    private String genre;
+
+    @Column(name = "meeting_time", nullable = false)
+    @Comment("모임 시간")
+    private LocalDateTime meetingTime;
+
+    @Column(name = "location", nullable = false, length = 255)
+    @Comment("모임 장소")
+    private String location;
+
+    @Column(name = "max_participants", nullable = false)
+    @Comment("최대 참여 인원")
+    private Integer maxParticipants;
+
+    @Column(name = "status", nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
+    @Comment("RECRUITING(모집중), COMPLETED(종료), CANCELLED(취소)")
+    private MeetingStatus meetingStatus;
+
+    @CreationTimestamp // 엔티티가 생성될 때 현재 시간을 자동으로 저장
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Comment("모임 생성 시점")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp // 엔티티가 업데이트될 때 현재 시간을 자동으로 저장
+    @Column(name = "updated_at", nullable = false)
+    @Comment("모임 정보 수정 시점")
+    private LocalDateTime updatedAt;
+
+    // 빌더 패턴을 사용한 생성자
+    @Builder
+    public Meeting(User host, String title, String description, String imageUrl, String bookTitle, String bookAuthor, String genre, LocalDateTime meetingTime, String location, int maxParticipants, String status) {
+        this.host = host;
+        this.title = title;
+        this.description = description;
+        this.imageUrl = imageUrl;
+        this.bookTitle = bookTitle;
+        this.bookAuthor = bookAuthor;
+        this.genre = genre;
+        this.meetingTime = meetingTime;
+        this.location = location;
+        this.maxParticipants = maxParticipants;
+        this.meetingStatus = meetingStatus;
+    }
+
 }

--- a/src/main/java/com/bookjuk/domain/meeting/MeetingStatus.java
+++ b/src/main/java/com/bookjuk/domain/meeting/MeetingStatus.java
@@ -1,4 +1,7 @@
 package com.bookjuk.domain.meeting;
 
-public class MeetingStatus {
+public enum MeetingStatus {
+    RECRUITING, // 모집중
+    COMPLETED,  // 종료
+    CANCELLED   // 취소
 }

--- a/src/main/java/com/bookjuk/domain/participant/MeetingParticipant.java
+++ b/src/main/java/com/bookjuk/domain/participant/MeetingParticipant.java
@@ -1,0 +1,5 @@
+package com.bookjuk.domain.participant;
+
+public class MeetingParticipant {
+
+}

--- a/src/main/java/com/bookjuk/domain/participant/MeetingParticipant.java
+++ b/src/main/java/com/bookjuk/domain/participant/MeetingParticipant.java
@@ -1,5 +1,86 @@
 package com.bookjuk.domain.participant;
 
+import com.bookjuk.domain.meeting.Meeting;
+import com.bookjuk.domain.user.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.Comment;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+/**
+ * MeetingParticipant 클래스는 모임에 참여하는 사용자 정보를 나타내는 엔티티이다.
+ *
+ * 이 클래스는 다음과 같은 주요 정보를 포함한다:
+ *
+ * - 고유 식별자 (id): 각 참여 정보를 구별하는 식별자
+ * - 모임 (meeting): 사용자가 참여하는 모임 정보
+ * - 사용자 (participant): 참여하는 사용자 정보
+ * - 역할 (role): 사용자의 모임 내 역할 (예: HOST, PARTICIPANT)
+ * - 상태 (status): 사용자 참여 상태 (예: PENDING, APPROVED, REJECTED 등)
+ * - 생성 시간 (createdAt): 참여 정보 생성 시점
+ * - 수정 시간 (updatedAt): 참여 상태가 변경된 시점
+ *
+ * 이 클래스는 lombok 라이브러리를 활용하여 getter 메서드, equals, hashCode, toString 메서드를 자동으로 생성한다.
+ * 불변성을 유지하기 위해 기본 생성자는 protected로 제한되어 있으며, 빌더 패턴을 지원하도록 설계될 수 있다.
+ */
+@Entity
+@Table(name = "meeting_participant")
+@Getter
+// MeetingParticipant 엔티티는 Meeting, User를 참조하고 있으므로,
+// meeting과 participant 필드를 exclude
+@ToString(exclude = {"meeting", "participant"})
+@EqualsAndHashCode(of = "id")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MeetingParticipant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    @Comment("참여 고유 식별자")
+    private Long id;
+
+    // Meeting 엔티티와 N대1 관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "meeting_id", nullable = false)
+    @Comment("참여 모임의 id (meeting.meeting_id 참조)")
+    private Meeting meeting;
+
+    // User 엔티티와 N대1 관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @Comment("참여 사용자의 user_id (user.user_id 참조)")
+    private User participant;
+
+    @Column(name = "role", nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
+    @Comment("HOST(주최자), PARTICIPANT(참여자)")
+    private ParticipantRole role;
+
+    @Column(name = "status", nullable = false, length = 20)
+    @Enumerated(EnumType.STRING)
+    @Comment("PENDING(신청), APPROVED(승인), REJECTED(거절), BANNED(차단), ATTENDED(출석), ABSENT(불참)")
+    private ParticipantStatus status;
+
+    @CreationTimestamp // 엔티티가 생성될 때 현재 시간을 자동으로 저장
+    @Column(name = "created_at", nullable = false, updatable = false)
+    @Comment("신청 시점")
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp // 엔티티가 업데이트될 때 현재 시간을 자동으로 저장
+    @Column(name = "updated_at", nullable = false)
+    @Comment("상태 변경 시점")
+    private LocalDateTime updatedAt;
+
+    // 빌더 패턴을 사용한 생성자
+    @Builder
+    public MeetingParticipant(Meeting meeting, User participant, ParticipantRole role, ParticipantStatus status) {
+        this.meeting = meeting;
+        this.participant = participant;
+        this.role = role;
+        this.status = status;
+    }
 
 }

--- a/src/main/java/com/bookjuk/domain/participant/MeetingParticipant.java
+++ b/src/main/java/com/bookjuk/domain/participant/MeetingParticipant.java
@@ -83,4 +83,11 @@ public class MeetingParticipant {
         this.status = status;
     }
 
+    /**
+     * 사용자의 모임 내 역할을 변경한다.
+     * @param role 변경할 역할 (ParticipantRole 열거형으로, 예: HOST, PARTICIPANT)
+     */
+    public void changeRole(ParticipantRole role) {
+        this.role = role;
+    }
 }

--- a/src/main/java/com/bookjuk/domain/participant/MeetingParticipantRepository.java
+++ b/src/main/java/com/bookjuk/domain/participant/MeetingParticipantRepository.java
@@ -1,4 +1,0 @@
-package com.bookjuk.domain.participant;
-
-public class MeetingParticipantRepository {
-}

--- a/src/main/java/com/bookjuk/domain/participant/ParticipantRole.java
+++ b/src/main/java/com/bookjuk/domain/participant/ParticipantRole.java
@@ -1,0 +1,6 @@
+package com.bookjuk.domain.participant;
+
+public enum ParticipantRole {
+    HOST,        // 주최자
+    PARTICIPANT  // 일반 참가자
+}

--- a/src/main/java/com/bookjuk/domain/participant/ParticipantStatus.java
+++ b/src/main/java/com/bookjuk/domain/participant/ParticipantStatus.java
@@ -1,0 +1,10 @@
+package com.bookjuk.domain.participant;
+
+public enum ParticipantStatus {
+    PENDING,   // 신청
+    APPROVED,  // 승인
+    REJECTED,  // 거절
+    BANNED,    // 차단
+    ATTENDED,  // 출석
+    ABSENT     // 불참
+}

--- a/src/main/java/com/bookjuk/domain/user/User.java
+++ b/src/main/java/com/bookjuk/domain/user/User.java
@@ -1,6 +1,7 @@
 package com.bookjuk.domain.user;
 
 import com.bookjuk.domain.meeting.Meeting;
+import com.bookjuk.domain.participant.MeetingParticipant;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -28,9 +29,14 @@ public class User {
     @Column(nullable = false, unique = true, length = 100)
     private String email;
 
+    // Meeting 엔티티와 1:N 관계
     @OneToMany(mappedBy = "host", cascade = CascadeType.ALL, orphanRemoval = true)
     List<Meeting> meetings = new ArrayList<>();
+//
+//    @OneToMany(mappedBy = "participant", cascade = CascadeType.ALL, orphanRemoval = true)
+//    List<Meeting> participants = new ArrayList<>();
 
+    // 중간 엔티티 기준 1:N
     @OneToMany(mappedBy = "participant", cascade = CascadeType.ALL, orphanRemoval = true)
-    List<Meeting> participants = new ArrayList<>();
+    private List<MeetingParticipant> meetingParticipants = new ArrayList<>();
 }

--- a/src/main/java/com/bookjuk/domain/user/User.java
+++ b/src/main/java/com/bookjuk/domain/user/User.java
@@ -2,18 +2,35 @@ package com.bookjuk.domain.user;
 
 import com.bookjuk.domain.meeting.Meeting;
 import jakarta.persistence.*;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class User {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // DB의 AUTO_INCREMENT를 따릅니다.
     @Column(name = "user_id")
     private Long id;
 
+    @Column(nullable = false, length = 50)
+    private String nickname;
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String email;
+
     @OneToMany(mappedBy = "host", cascade = CascadeType.ALL, orphanRemoval = true)
     List<Meeting> meetings = new ArrayList<>();
+
+    @OneToMany(mappedBy = "participant", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<Meeting> participants = new ArrayList<>();
 }

--- a/src/main/java/com/bookjuk/domain/user/User.java
+++ b/src/main/java/com/bookjuk/domain/user/User.java
@@ -1,4 +1,19 @@
 package com.bookjuk.domain.user;
 
+import com.bookjuk.domain.meeting.Meeting;
+import jakarta.persistence.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
 public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @OneToMany(mappedBy = "host", cascade = CascadeType.ALL, orphanRemoval = true)
+    List<Meeting> meetings = new ArrayList<>();
 }

--- a/src/main/java/com/bookjuk/repository/meeting/MeetingRepository.java
+++ b/src/main/java/com/bookjuk/repository/meeting/MeetingRepository.java
@@ -3,5 +3,11 @@ package com.bookjuk.repository.meeting;
 import com.bookjuk.domain.meeting.Meeting;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+
+    // 쿼리 메서드, 전달된 문자열과 제목명이 같은 모임을 찾음
+    List<Meeting> findByTitle(String title);
 }

--- a/src/main/java/com/bookjuk/repository/meeting/MeetingRepository.java
+++ b/src/main/java/com/bookjuk/repository/meeting/MeetingRepository.java
@@ -1,4 +1,7 @@
 package com.bookjuk.repository.meeting;
 
-public interface MeetingRepository {
+import com.bookjuk.domain.meeting.Meeting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MeetingRepository extends JpaRepository<Meeting, Long> {
 }

--- a/src/main/java/com/bookjuk/repository/participant/MeetingParticipantRepository.java
+++ b/src/main/java/com/bookjuk/repository/participant/MeetingParticipantRepository.java
@@ -1,4 +1,7 @@
 package com.bookjuk.repository.participant;
 
-public interface MeetingParticipantRepository {
+import com.bookjuk.domain.participant.MeetingParticipant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MeetingParticipantRepository extends JpaRepository<MeetingParticipant, Long> {
 }

--- a/src/main/java/com/bookjuk/repository/user/UserRepository.java
+++ b/src/main/java/com/bookjuk/repository/user/UserRepository.java
@@ -1,4 +1,7 @@
 package com.bookjuk.repository.user;
 
-public interface UserRepository {
+import com.bookjuk.domain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
 }

--- a/src/test/java/com/bookjuk/repository/meeting/MeetingRepositoryTest.java
+++ b/src/test/java/com/bookjuk/repository/meeting/MeetingRepositoryTest.java
@@ -1,0 +1,243 @@
+package com.bookjuk.repository.meeting;
+
+import com.bookjuk.domain.meeting.Meeting;
+import com.bookjuk.domain.meeting.MeetingStatus;
+import com.bookjuk.domain.participant.MeetingParticipant;
+import com.bookjuk.domain.participant.ParticipantRole;
+import com.bookjuk.domain.participant.ParticipantStatus;
+import com.bookjuk.domain.user.User;
+import com.bookjuk.repository.participant.MeetingParticipantRepository;
+import com.bookjuk.repository.user.UserRepository;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional  // 연관관계 사용시 필수
+class MeetingRepositoryTest {
+
+    @Autowired
+    MeetingRepository meetingRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    MeetingParticipantRepository meetingParticipantRepository;
+
+    @Autowired
+    EntityManager em;
+
+    @BeforeEach
+    void insertBulk() {
+        meetingParticipantRepository.deleteAll();
+        meetingRepository.deleteAll();
+        userRepository.deleteAll();
+        // 유저정보 만들기 (임시 테스트용)
+        User u1 = User.builder()
+                .nickname("치이카와")
+                .email("abc123@naver.com")
+                .build();
+        User u2 = User.builder()
+                .nickname("하치와레")
+                .email("abc123@google.com")
+                .build();
+        User u3 = User.builder()
+                .nickname("우사기")
+                .email("abc123@daum.net")
+                .build();
+
+        List<User> users = userRepository.saveAllAndFlush(
+                List.of(u1, u2, u3)
+        );
+
+        // 모임정보 만들기
+        Meeting m1 = Meeting.builder()
+                .host(u1)
+                .title("먼작귀친구들")
+                .description("책 읽으며 놀아요.")
+                .imageUrl("https://example.com/image.jpg")
+                .bookTitle("먼작귀")
+                .bookAuthor("나가노작가")
+                .genre("동화")
+                .meetingTime(LocalDateTime.of(2025, 8, 20, 19, 0))
+                .region("경기도")
+                .city("안산시")
+                .maxParticipants(6)
+                .meetingStatus(MeetingStatus.RECRUITING)
+                .build();
+        Meeting m2 = Meeting.builder()
+                .host(u2)
+                .title("가나디친구들")
+                .description("책을 읽어봅시다.")
+                .imageUrl("https://example.com/image2.jpg")
+                .bookTitle("가나디")
+                .bookAuthor("짤쓸사람")
+                .genre("동화")
+                .meetingTime(LocalDateTime.of(2025, 8, 18, 19, 0))
+                .region("경기도")
+                .city("안양시")
+                .maxParticipants(8)
+                .meetingStatus(MeetingStatus.RECRUITING)
+                .build();
+        Meeting m3 = Meeting.builder()
+                .host(u2)
+                .title("초원의 왕")
+                .description("왕이 되어봅시다.")
+                .imageUrl("https://example.com/image3.jpg")
+                .bookTitle("라이온킹")
+                .bookAuthor("무파사")
+                .genre("동화")
+                .meetingTime(LocalDateTime.of(2025, 8, 21, 19, 0))
+                .region("경기도")
+                .city("구리시")
+                .maxParticipants(4)
+                .meetingStatus(MeetingStatus.RECRUITING)
+                .build();
+
+        List<Meeting> meetings = meetingRepository.saveAllAndFlush(
+                List.of(m1, m2, m3)
+        );
+        
+        // 참가자 정보 만들기
+        MeetingParticipant mp1 = MeetingParticipant.builder()
+                .participant(u1)
+                .meeting(m1)
+                .role(ParticipantRole.HOST)
+                .status(ParticipantStatus.APPROVED)
+                .build();
+        MeetingParticipant mp2 = MeetingParticipant.builder()
+                .participant(u2)
+                .meeting(m1)
+                .role(ParticipantRole.PARTICIPANT)
+                .status(ParticipantStatus.APPROVED)
+                .build();
+        MeetingParticipant mp3 = MeetingParticipant.builder()
+                .participant(u3)
+                .meeting(m1)
+                .role(ParticipantRole.PARTICIPANT)
+                .status(ParticipantStatus.PENDING)
+                .build();
+        MeetingParticipant mp4 = MeetingParticipant.builder()
+                .participant(u1)
+                .meeting(m2)
+                .role(ParticipantRole.PARTICIPANT)
+                .status(ParticipantStatus.PENDING)
+                .build();
+        MeetingParticipant mp5 = MeetingParticipant.builder()
+                .participant(u2)
+                .meeting(m2)
+                .role(ParticipantRole.HOST)
+                .status(ParticipantStatus.APPROVED)
+                .build();
+        MeetingParticipant mp6 = MeetingParticipant.builder()
+                .participant(u2)
+                .meeting(m3)
+                .role(ParticipantRole.HOST)
+                .status(ParticipantStatus.APPROVED)
+                .build();
+
+
+        List<MeetingParticipant> meetingParticipants = meetingParticipantRepository.saveAllAndFlush(
+                List.of(mp1, mp2, mp3, mp4, mp5, mp6)
+        );
+
+        em.flush();
+        em.clear();
+    }
+
+
+    // ========== MeetingRepository: CREATE + READ ==========
+    @Test
+    @DisplayName("미팅 엔티티를 저장하면 ID가 생성되고 조회가 된다.")
+    void meeting_create_and_read() {
+        // given
+        User u = User.builder()
+                .nickname("루피")
+                .email("lulu123@naver.com")
+                .build();
+        userRepository.save(u);
+
+
+        Meeting newMeeting = Meeting.builder()
+                .host(u)
+                .title("가을 낭독회")
+                .description("낭독하며 토론해요")
+                .imageUrl("https://example.com/image5.jpg")
+                .bookTitle("가을의 시")
+                .bookAuthor("이시인")
+                .genre("시")
+                .meetingTime(LocalDateTime.of(2025, 8, 27, 19, 0))
+                .region("서울광역시")
+                .city("강남구")
+                .maxParticipants(7)
+                .meetingStatus(MeetingStatus.RECRUITING)
+                .build();
+
+        // when
+        Meeting saved = meetingRepository.save(newMeeting);
+
+        em.flush();
+        em.clear();
+
+        // then
+        assertNotNull(saved.getId());
+        Meeting found = meetingRepository.findById(saved.getId()).orElse(null);
+        assertNotNull(found);
+        assertEquals(newMeeting.getTitle(), found.getTitle());
+        assertEquals(u.getId(), found.getHost().getId());
+    }
+
+    // ========== MeetingRepository: UPDATE ==========
+    @Test
+    @DisplayName("기존 미팅이 주어졌을때 제목을 수정 후 저장하면 수정 내용이 반영된다.")
+    void meeting_update_title() {
+        // given
+        String title = "먼작귀친구들";
+        List<Meeting> meetings = meetingRepository.findByTitle(title);
+
+        // when (더티 체킹)
+        String updatedTitle = meetings.get(0).getTitle() + "-수정";
+        meetings.get(0).changeTitle(updatedTitle);
+        em.flush();
+        em.clear();
+
+        // then
+        List<Meeting> changedMeeting = meetingRepository.findByTitle(updatedTitle);
+        assertEquals(updatedTitle, changedMeeting.get(0).getTitle());
+    }
+
+    // ========== MeetingRepository: DELETE ==========
+    @Test
+    @DisplayName("기존 미팅이 주어졌을때 삭제하면 더 이상 조회되지 않는다.")
+    void meetingDelete() {
+        // given
+        String title = "먼작귀친구들";
+        List<Meeting> meetings = meetingRepository.findByTitle(title);
+        Long givenId = meetings.get(0).getId();
+
+        // when
+        meetingRepository.deleteById(givenId);
+        em.flush();
+        em.clear();
+
+        // then
+        assertTrue(meetingRepository.findById(givenId).isEmpty());
+    }
+
+
+
+
+
+}

--- a/src/test/java/com/bookjuk/repository/meeting/MeetingRepositoryTest.java
+++ b/src/test/java/com/bookjuk/repository/meeting/MeetingRepositoryTest.java
@@ -39,21 +39,27 @@ class MeetingRepositoryTest {
     @Autowired
     EntityManager em;
 
+    private User u1, u2, u3;
+    private Meeting m1, m2, m3;
+    private MeetingParticipant mp1, mp2, mp3, mp4, mp5, mp6;
+
+    private List<MeetingParticipant> meetingParticipants;
+
     @BeforeEach
     void insertBulk() {
         meetingParticipantRepository.deleteAll();
         meetingRepository.deleteAll();
         userRepository.deleteAll();
         // 유저정보 만들기 (임시 테스트용)
-        User u1 = User.builder()
+        u1 = User.builder()
                 .nickname("치이카와")
                 .email("abc123@naver.com")
                 .build();
-        User u2 = User.builder()
+        u2 = User.builder()
                 .nickname("하치와레")
                 .email("abc123@google.com")
                 .build();
-        User u3 = User.builder()
+        u3 = User.builder()
                 .nickname("우사기")
                 .email("abc123@daum.net")
                 .build();
@@ -63,7 +69,7 @@ class MeetingRepositoryTest {
         );
 
         // 모임정보 만들기
-        Meeting m1 = Meeting.builder()
+        m1 = Meeting.builder()
                 .host(u1)
                 .title("먼작귀친구들")
                 .description("책 읽으며 놀아요.")
@@ -77,7 +83,7 @@ class MeetingRepositoryTest {
                 .maxParticipants(6)
                 .meetingStatus(MeetingStatus.RECRUITING)
                 .build();
-        Meeting m2 = Meeting.builder()
+        m2 = Meeting.builder()
                 .host(u2)
                 .title("가나디친구들")
                 .description("책을 읽어봅시다.")
@@ -91,7 +97,7 @@ class MeetingRepositoryTest {
                 .maxParticipants(8)
                 .meetingStatus(MeetingStatus.RECRUITING)
                 .build();
-        Meeting m3 = Meeting.builder()
+        m3 = Meeting.builder()
                 .host(u2)
                 .title("초원의 왕")
                 .description("왕이 되어봅시다.")
@@ -111,37 +117,37 @@ class MeetingRepositoryTest {
         );
         
         // 참가자 정보 만들기
-        MeetingParticipant mp1 = MeetingParticipant.builder()
+        mp1 = MeetingParticipant.builder()
                 .participant(u1)
                 .meeting(m1)
                 .role(ParticipantRole.HOST)
                 .status(ParticipantStatus.APPROVED)
                 .build();
-        MeetingParticipant mp2 = MeetingParticipant.builder()
+        mp2 = MeetingParticipant.builder()
                 .participant(u2)
                 .meeting(m1)
                 .role(ParticipantRole.PARTICIPANT)
                 .status(ParticipantStatus.APPROVED)
                 .build();
-        MeetingParticipant mp3 = MeetingParticipant.builder()
+        mp3 = MeetingParticipant.builder()
                 .participant(u3)
                 .meeting(m1)
                 .role(ParticipantRole.PARTICIPANT)
                 .status(ParticipantStatus.PENDING)
                 .build();
-        MeetingParticipant mp4 = MeetingParticipant.builder()
+        mp4 = MeetingParticipant.builder()
                 .participant(u1)
                 .meeting(m2)
                 .role(ParticipantRole.PARTICIPANT)
                 .status(ParticipantStatus.PENDING)
                 .build();
-        MeetingParticipant mp5 = MeetingParticipant.builder()
+        mp5 = MeetingParticipant.builder()
                 .participant(u2)
                 .meeting(m2)
                 .role(ParticipantRole.HOST)
                 .status(ParticipantStatus.APPROVED)
                 .build();
-        MeetingParticipant mp6 = MeetingParticipant.builder()
+        mp6 = MeetingParticipant.builder()
                 .participant(u2)
                 .meeting(m3)
                 .role(ParticipantRole.HOST)
@@ -149,7 +155,7 @@ class MeetingRepositoryTest {
                 .build();
 
 
-        List<MeetingParticipant> meetingParticipants = meetingParticipantRepository.saveAllAndFlush(
+        meetingParticipants = meetingParticipantRepository.saveAllAndFlush(
                 List.of(mp1, mp2, mp3, mp4, mp5, mp6)
         );
 
@@ -161,7 +167,7 @@ class MeetingRepositoryTest {
     // ========== MeetingRepository: CREATE + READ ==========
     @Test
     @DisplayName("미팅 엔티티를 저장하면 ID가 생성되고 조회가 된다.")
-    void meeting_create_and_read() {
+    void meetingCreateAndReadTest() {
         // given
         User u = User.builder()
                 .nickname("루피")
@@ -202,7 +208,7 @@ class MeetingRepositoryTest {
     // ========== MeetingRepository: UPDATE ==========
     @Test
     @DisplayName("기존 미팅이 주어졌을때 제목을 수정 후 저장하면 수정 내용이 반영된다.")
-    void meeting_update_title() {
+    void meetingUpdateTitleTest() {
         // given
         String title = "먼작귀친구들";
         List<Meeting> meetings = meetingRepository.findByTitle(title);
@@ -237,7 +243,91 @@ class MeetingRepositoryTest {
     }
 
 
+    // ========== MeetingParticipantRepository: CREATE + READ ==========
+    @Test
+    @DisplayName("참가자 엔티티가 주어지고, 저장하면 ID가 생성되고 조회된다.")
+    void CreateAndReadTest() {
+        // given
+        User u = User.builder()
+                .nickname("루피")
+                .email("lulu123@naver.com")
+                .build();
+        userRepository.save(u);
+
+        Meeting m = Meeting.builder()
+                .host(u)
+                .title("가을 낭독회")
+                .description("낭독하며 토론해요")
+                .imageUrl("https://example.com/image5.jpg")
+                .bookTitle("가을의 시")
+                .bookAuthor("이시인")
+                .genre("시")
+                .meetingTime(LocalDateTime.of(2025, 8, 27, 19, 0))
+                .region("서울광역시")
+                .city("강남구")
+                .maxParticipants(7)
+                .meetingStatus(MeetingStatus.RECRUITING)
+                .build();
+        meetingRepository.save(m);
+
+        MeetingParticipant mp = MeetingParticipant.builder()
+                .participant(u)
+                .meeting(m)
+                .role(ParticipantRole.PARTICIPANT)
+                .status(ParticipantStatus.APPROVED)
+                .build();
+
+        // when
+        MeetingParticipant saved = meetingParticipantRepository.save(mp);
+        em.flush();
+        em.clear();
+
+        // then
+        assertNotNull(saved.getId());
+        MeetingParticipant found = meetingParticipantRepository.findById(saved.getId()).orElse(null);
+        assertNotNull(found);
+        assertEquals(u.getId(), found.getParticipant().getId());
+        assertEquals(m.getId(), found.getMeeting().getId());
+        assertEquals("PARTICIPANT", found.getRole().toString());
+    }
 
 
+    // ========== MeetingParticipantRepository: UPDATE ==========
+    @Test
+    @DisplayName("기존 참가자의 role을 변경하면 변경 사항이 반영된다.")
+    void UpdateRoleTest() {
+        // given
+        MeetingParticipant any = meetingParticipants.get(2); // m1의 u3 (PARTICIPANT)
+        Long pid = any.getId();
+        MeetingParticipant found = meetingParticipantRepository.findById(pid).orElseThrow();
+
+        // when
+        found.changeRole(ParticipantRole.HOST);
+        em.flush();
+        em.clear();
+
+        // then
+        MeetingParticipant reloaded = meetingParticipantRepository.findById(pid).orElseThrow();
+        assertEquals("HOST", reloaded.getRole().toString());
+    }
+
+
+    // ========== MeetingParticipantRepository: DELETE ==========
+    @Test
+    @DisplayName("기존 참가자를 삭제하면 더 이상 조회되지 않는다.")
+    void participantDeleteTest() {
+        // given
+        MeetingParticipant target = meetingParticipants.get(0);
+        Long pid = target.getId();
+        assertTrue(meetingParticipantRepository.findById(pid).isPresent());
+
+        // when
+        meetingParticipantRepository.deleteById(pid);
+        em.flush();
+        em.clear();
+
+        // then
+        assertTrue(meetingParticipantRepository.findById(pid).isEmpty());
+    }
 
 }


### PR DESCRIPTION
## 개요
- 모임 관련 Entity, Repository를 수정하고 기본 CRUD를 테스트 했습니다.
- 그 과정에서 테스트를 하기 위해서 임시로 User Entity와 Repository를 작성하였습니다.

## 변경 사항
- Meeting, MeetingParticipant, User 엔티티를 수정하여 도메인 설계 및 필드를 정의
- Meeting 엔티티의 모임 상태를 Enum 형태(MeetingStatus.java)로 관리
- MeetingParticipant 엔티티의 참가자 역할을 Enum 형태(ParticipantRole.java)로 관리
- MeetingParticipant 엔티티의 참가자 상태를 Enum 형태(ParticipantStatus.java)로 관리

User, MeetingParticipant, Meeting의 연관관계를 아래와 같이 정의함.
- User : MeetingParticipant = 1 : N
- Meeting : MeetingParticipant = 1 : N
- User : Meeting = 1 : N
- User와 Meeting은 중간 엔티티인 MeetingParticipant를 통해 M : N 관계를 가짐.
- 하지만 Meeting 엔티티의 방장 아이디(host_id)를 통해 1 : N의 연관관계를 갖기도 함.

## 테스트 방법
- 로컬에서 직접 테스트 메서드를 작성하여 테스트
- BDD(given-when-then) 스타일로 MeetingRepository, MeetingParticipantRepository을 JPA를 이용하여 간단한 CRUD 테스트를 진행

## 관련 이슈
- Resolves #18 
