### PR TITLE
Feat: 모임(Meeting) 도메인 기능 개선 및 구조 리팩토링

### DIFF
--- a/src/main/java/com/bookjuk/domain/meeting/Meeting.java
+++ b/src/main/java/com/bookjuk/domain/meeting/Meeting.java
@@ -1,6 +1,7 @@
 package com.bookjuk.domain.meeting;
 
 import com.bookjuk.domain.user.User;
+import com.bookjuk.dto.meeting.MeetingUpdateRequest;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Max;
 import lombok.AccessLevel;
@@ -143,6 +144,32 @@ public class Meeting {
         this.detailAddress = detailAddress;
         this.maxParticipants = maxParticipants;
         this.meetingStatus = meetingStatus;
+    }
+
+    /**
+     * 모임 정보 수정 메서드
+     * DTO로부터 받은 데이터로 엔티티의 상태를 변경합니다.
+     * 이미지 URL은 별도로 받아와서 업데이트합니다.
+     *
+     * @param request 수정할 정보가 담긴 DTO
+     * @param imageUrl 새로 업로드된 이미지의 URL (변경이 없으면 null 또는 기존 URL)
+     */
+    public void update(MeetingUpdateRequest request, String imageUrl) {
+        this.title = request.getTitle();
+        this.description = request.getDescription();
+        this.bookTitle = request.getBookTitle();
+        this.bookAuthor = request.getBookAuthor();
+        this.genre = request.getGenre();
+        this.meetingTime = request.getMeetingTime();
+        this.region = request.getRegion();
+        this.city = request.getCity();
+        this.detailAddress = request.getDetailAddress();
+        this.maxParticipants = request.getMaxParticipants();
+
+        // 이미지 URL이 null이 아닌 경우에만 업데이트
+        if (imageUrl != null) {
+            this.imageUrl = imageUrl;
+        }
     }
 
 }

--- a/src/main/java/com/bookjuk/domain/user/User.java
+++ b/src/main/java/com/bookjuk/domain/user/User.java
@@ -2,11 +2,13 @@ package com.bookjuk.domain.user;
 
 import com.bookjuk.domain.meeting.Meeting;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @Entity
+@Getter
 public class User {
 
     @Id

--- a/src/main/java/com/bookjuk/dto/meeting/MeetingDetailResponse.java
+++ b/src/main/java/com/bookjuk/dto/meeting/MeetingDetailResponse.java
@@ -1,0 +1,67 @@
+package com.bookjuk.dto.meeting;
+
+import com.bookjuk.domain.meeting.Meeting;
+import com.bookjuk.domain.meeting.MeetingStatus;
+import com.bookjuk.domain.user.User;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class MeetingDetailResponse {
+
+    private Long meetingId;
+    private String title;
+    private String description;
+    private String imageUrl;
+    private String bookTitle;
+    private String bookAuthor;
+    private String genre;
+    private LocalDateTime meetingTime;
+    private String location; // 주소를 하나로 합친 필드
+    private int maxParticipants;
+    private int currentParticipants; // 현재 참여 인원
+    private MeetingStatus meetingStatus;
+
+    // HostInfoResponseDto 대신 User의 정보를 직접 필드로 선언
+    private Long hostId;
+
+    /**
+     * Meeting 엔티티를 DTO로 변환하는 정적 팩토리 메서드
+     * @param meeting 원본 Meeting 엔티티
+     * @param currentParticipants 서비스 계층에서 계산된 현재 참여 인원
+     * @return 변환된 DTO 객체
+     */
+    public static MeetingDetailResponse from(Meeting meeting, int currentParticipants) {
+        MeetingDetailResponse dto = new MeetingDetailResponse();
+
+        // 1. 모임 관련 정보 설정
+        dto.setMeetingId(meeting.getId());
+        dto.setTitle(meeting.getTitle());
+        dto.setDescription(meeting.getDescription());
+        dto.setImageUrl(meeting.getImageUrl());
+        dto.setBookTitle(meeting.getBookTitle());
+        dto.setBookAuthor(meeting.getBookAuthor());
+        dto.setGenre(meeting.getGenre());
+        dto.setMeetingTime(meeting.getMeetingTime());
+        dto.setMaxParticipants(meeting.getMaxParticipants());
+        dto.setMeetingStatus(meeting.getMeetingStatus());
+        dto.setCurrentParticipants(currentParticipants);
+
+        // 2. 주소 정보 조합
+        String fullLocation = String.join(" ", meeting.getRegion(), meeting.getCity(), meeting.getDetailAddress()).trim();
+        dto.setLocation(fullLocation);
+
+        // 3. 호스트 정보 설정 (User 엔티티에서 직접 가져옴)
+        User host = meeting.getHost();
+        if (host != null) {
+            dto.setHostId(host.getId());
+        }
+
+        return dto;
+    }
+
+
+}

--- a/src/main/java/com/bookjuk/dto/meeting/MeetingUpdateRequest.java
+++ b/src/main/java/com/bookjuk/dto/meeting/MeetingUpdateRequest.java
@@ -1,0 +1,49 @@
+package com.bookjuk.dto.meeting;
+
+import jakarta.validation.constraints.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class MeetingUpdateRequest {
+
+    @NotEmpty(message = "모임 제목을 입력해주세요.")
+    @Size(max = 255, message = "모임 제목은 255자를 넘을 수 없습니다.")
+    private String title;
+
+    @Size(max = 65535, message = "모임 상세 설명이 너무 깁니다.")
+    private String description;
+
+    @NotEmpty(message = "선정 도서 제목을 입력해주세요.")
+    @Size(max = 255, message = "도서 제목은 255자를 넘을 수 없습니다.")
+    private String bookTitle;
+
+    @NotEmpty(message = "선정 도서 저자를 입력해주세요.")
+    @Size(max = 100, message = "저자 이름은 100자를 넘을 수 없습니다.")
+    private String bookAuthor;
+
+    @Size(max = 100, message = "장르 이름은 100자를 넘을 수 없습니다.")
+    private String genre;
+
+    @NotNull(message = "모임 시간을 입력해주세요.")
+    @Future(message = "모임 시간은 현재 시간 이후로 설정해야 합니다.")
+    private LocalDateTime meetingTime;
+
+    @NotEmpty(message = "시/도를 입력해주세요.")
+    @Size(max = 20, message = "시/도는 20자를 넘을 수 없습니다.")
+    private String region;
+
+    @NotEmpty(message = "시/구/군을 입력해주세요.")
+    @Size(max = 30, message = "시/구/군은 30자를 넘을 수 없습니다.")
+    private String city;
+
+    @Size(max = 255, message = "상세 주소는 255자를 넘을 수 없습니다.")
+    private String detailAddress;
+
+    @NotNull(message = "최대 참여 인원을 입력해주세요.")
+    @Min(value = 2, message = "최대 참여 인원은 최소 2명 이상이어야 합니다.")
+    @Max(value = 10, message = "최대 참여 인원은 10명을 넘을 수 없습니다.")
+    private int maxParticipants;
+}

--- a/src/main/java/com/bookjuk/repository/meeting/MeetingRepository.java
+++ b/src/main/java/com/bookjuk/repository/meeting/MeetingRepository.java
@@ -1,4 +1,60 @@
 package com.bookjuk.repository.meeting;
 
-public interface MeetingRepository {
+import com.bookjuk.domain.meeting.Meeting;
+import com.bookjuk.domain.meeting.MeetingStatus;
+import com.bookjuk.domain.user.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MeetingRepository extends JpaRepository<Meeting, Long> {
+
+    // JpaRepository가 기본으로 제공하는 메서드들:
+    // - save(Meeting meeting): 모임 생성 및 수정 (ID가 없으면 생성, 있으면 수정)
+    // - findById(Long id): ID로 모임 단건 조회
+    // - findAll(): 모든 모임 조회
+    // - delete(Meeting meeting): 모임 삭제
+    // ... 등등
+
+    /**
+     * 특정 상태(status)의 모임 목록을 페이징 처리하여 조회
+     * 예: 모집중(RECRUITING)인 모임만 최신순으로 10개씩 조회
+     * @param status 조회할 모임 상태 (RECRUITING, COMPLETED, CANCELLED)
+     * @param pageable 페이징 정보 (페이지 번호, 페이지 크기, 정렬 순서 등)
+     * @return 페이징된 모임 목록
+     */
+    Page<Meeting> findByMeetingStatus(MeetingStatus status, Pageable pageable);
+
+    /**
+     * 특정 지역(region, city)과 상태(status)에 맞는 모임 목록을 페이징 처리하여 조회
+     * 예: '서울시 강남구'에서 '모집중'인 모임 목록 조회
+     * @param region 시/도
+     * @param city 시/구/군
+     * @param status 모임 상태
+     * @param pageable 페이징 정보
+     * @return 페이징된 모임 목록
+     */
+    Page<Meeting> findByRegionAndCityAndMeetingStatus(String region, String city, MeetingStatus status, Pageable pageable);
+
+    /**
+     * 특정 사용자가 주최한(host) 모임 목록을 조회
+     * '마이페이지 > 내가 만든 모임' 기능에서 활용할 수 있습니다.
+     * @param host 주최자(User 객체)
+     * @return 해당 사용자가 주최한 모임 리스트
+     */
+    List<Meeting> findByHost(User host);
+
+    /**
+     * 모임 제목(title)에 특정 키워드가 포함된 모임 목록을 페이징 처리하여 조회
+     * 검색 기능에서 활용할 수 있습니다.
+     * @param keyword 검색할 키워드
+     * @param pageable 페이징 정보
+     * @return 페이징된 모임 목록
+     */
+    Page<Meeting> findByTitleContaining(String keyword, Pageable pageable);
+
 }

--- a/src/main/java/com/bookjuk/service/MeetingService.java
+++ b/src/main/java/com/bookjuk/service/MeetingService.java
@@ -1,4 +1,12 @@
 package com.bookjuk.service;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
 public class MeetingService {
+
+
+
 }


### PR DESCRIPTION
# 주요 변경사항
---
- 모임 수정 기능 추가 및 관련 DTO 설계
1. 모임 정보를 수정하기 위한 요청 데이터를 담는 MeetingUpdateRequest DTO를 추가
2. 모임 상세 정보를 클라이언트에 응답하기 위한 MeetingDetailResponse DTO를 추가
3. Meeting 엔티티에 DTO로부터 받은 데이터로 상태를 변경하는 update() 메서드를 구현하여 핵심 비즈니스 로직을 엔티티 내부에 캡슐화

---
-  테스트 여부 (수동/자동)
X
---

# 관련 이슈 번호
- #29  