### PR TITLE
feat: #33 API 응답 DTO 구현

### DIFF
--- a/src/main/java/com/bookjuk/dto/common/ApiResponse.java
+++ b/src/main/java/com/bookjuk/dto/common/ApiResponse.java
@@ -1,0 +1,40 @@
+package com.bookjuk.dto.common;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * 클라이언트에게 일관적인 응답의 포맷을 위한 객체
+ */
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ApiResponse<T> {
+
+    // 응답 성공 여부
+    private boolean success;
+
+    // 응답 메시지
+    private String message;
+
+    // 응답 시간
+    private LocalDateTime timestamp;
+
+    // 응답 JSON
+    private T data;
+
+    // 응답 객체 생성 팩토리 메서드
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return ApiResponse.<T>builder()
+                .success(true)
+                .message(message)
+                .timestamp(LocalDateTime.now())
+                .data(data)
+                .build();
+    }
+}


### PR DESCRIPTION
## 개요
- 클라이언트의 요청에 일관적으로 응답할 수 있는 응답 DTO를 구현했습니다.

## 변경 사항
- ApiResponse.java 응답 DTO 클래스를 생성했습니다.

## 테스트 방법
- 응답 DTO 생성으로서 부가적인 테스트는 시행하지 않았습니다.

## 관련 이슈
- Resolves #33 
