### PR TITLE
fix: MeetingParticipantCustom 이름 변경 및 Repository 수정, ReviewService 커스텀 메서드 접근 문제 해결

### DIFF
--- a/src/main/java/com/bookjuk/repository/participant/MeetingParticipantCustom.java
+++ b/src/main/java/com/bookjuk/repository/participant/MeetingParticipantCustom.java
@@ -3,9 +3,8 @@ package com.bookjuk.repository.participant;
 import com.bookjuk.domain.user.User;
 
 import java.util.List;
-import java.util.Optional;
 
-public interface MeetingParticipantCustomRepository {
+public interface MeetingParticipantCustom {
 
     // 미팅 id로 미팅 참여자 찾기
     List<User> findMeetingParticipantsByMeetingId(Long id);

--- a/src/main/java/com/bookjuk/repository/participant/MeetingParticipantImpl.java
+++ b/src/main/java/com/bookjuk/repository/participant/MeetingParticipantImpl.java
@@ -10,7 +10,7 @@ import static com.bookjuk.domain.participant.QMeetingParticipant.meetingParticip
 
 
 @RequiredArgsConstructor
-public class MeetingParticipantRepositoryImpl implements MeetingParticipantCustomRepository{
+public class MeetingParticipantImpl implements MeetingParticipantCustom {
 
     // queryDsl을 사용하기 위한 의존객체
     private final JPAQueryFactory factory;

--- a/src/main/java/com/bookjuk/repository/participant/MeetingParticipantRepository.java
+++ b/src/main/java/com/bookjuk/repository/participant/MeetingParticipantRepository.java
@@ -1,24 +1,22 @@
 package com.bookjuk.repository.participant;
 
-import com.bookjuk.domain.participant.MeetingParticipant;
 import com.bookjuk.domain.participant.ParticipantRole;
 import com.bookjuk.domain.participant.ParticipantStatus;
-import com.bookjuk.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import java.util.List;
+
 import java.util.Optional;
 
 @Repository
-public interface MeetingParticipantRepository extends JpaRepository<MeetingParticipant, Long> {
+public interface MeetingParticipantRepository extends JpaRepository<com.bookjuk.domain.participant.MeetingParticipant, Long>, MeetingParticipantCustom {
 
     // 파생 쿼리: 연관관계 경로를 정확히 기술 (Meeting.id / User.id)
     boolean existsByMeeting_IdAndParticipant_IdAndStatus(
             Long meetingId, Long userId, ParticipantStatus status);
 
-    Optional<MeetingParticipant> findByMeeting_IdAndParticipant_Id(
+    Optional<MeetingParticipantRepository> findByMeeting_IdAndParticipant_Id(
             Long meetingId, Long userId);
 
     boolean existsByMeeting_IdAndParticipant_IdAndRole(

--- a/src/main/java/com/bookjuk/repository/review/MeetingReviewRepositoryImpl.java
+++ b/src/main/java/com/bookjuk/repository/review/MeetingReviewRepositoryImpl.java
@@ -1,13 +1,9 @@
 package com.bookjuk.repository.review;
 
 import com.bookjuk.domain.meeting.Meeting;
-import com.bookjuk.domain.review.QMeetingReview;
 import com.bookjuk.domain.user.User;
-import com.bookjuk.repository.participant.MeetingParticipantCustomRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-
-import java.util.List;
 
 import static com.bookjuk.domain.review.QMeetingReview.meetingReview;
 

--- a/src/main/java/com/bookjuk/service/ReviewService.java
+++ b/src/main/java/com/bookjuk/service/ReviewService.java
@@ -1,25 +1,20 @@
 package com.bookjuk.service;
 
 import com.bookjuk.domain.meeting.Meeting;
-import com.bookjuk.domain.meeting.MeetingStatus;
 import com.bookjuk.domain.review.MeetingReview;
 import com.bookjuk.domain.user.User;
 import com.bookjuk.exception.CustomException;
 import com.bookjuk.exception.ErrorCode;
 import com.bookjuk.repository.participant.MeetingParticipantRepository;
-import com.bookjuk.dto.review.ReviewRequest;
 import com.bookjuk.dto.review.ReviewResponse;
 import com.bookjuk.repository.meeting.MeetingRepository;
 import com.bookjuk.repository.review.MeetingReviewRepository;
 import com.bookjuk.repository.user.UserRepository;
-import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 import static com.bookjuk.domain.meeting.MeetingStatus.COMPLETED;
 

--- a/src/test/java/com/bookjuk/repository/meeting/MeetingRepositoryTest.java
+++ b/src/test/java/com/bookjuk/repository/meeting/MeetingRepositoryTest.java
@@ -1,8 +1,6 @@
 package com.bookjuk.repository.meeting;
 
 import com.bookjuk.domain.meeting.Meeting;
-import com.bookjuk.domain.meeting.MeetingStatus;
-import com.bookjuk.domain.participant.MeetingParticipant;
 import com.bookjuk.domain.participant.ParticipantRole;
 import com.bookjuk.domain.participant.ParticipantStatus;
 import com.bookjuk.domain.user.User;
@@ -14,12 +12,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -41,9 +37,9 @@ class MeetingRepositoryTest {
 
     private User u1, u2, u3;
     private Meeting m1, m2, m3;
-    private MeetingParticipant mp1, mp2, mp3, mp4, mp5, mp6;
+    private com.bookjuk.domain.participant.MeetingParticipant mp1, mp2, mp3, mp4, mp5, mp6;
 
-    private List<MeetingParticipant> meetingParticipants;
+    private List<com.bookjuk.domain.participant.MeetingParticipant> meetingParticipants;
 
     @BeforeEach
     void insertBulk() {
@@ -118,37 +114,37 @@ class MeetingRepositoryTest {
         );
         
         // 참가자 정보 만들기
-        mp1 = MeetingParticipant.builder()
+        mp1 = com.bookjuk.domain.participant.MeetingParticipant.builder()
                 .participant(u1)
                 .meeting(m1)
                 .role(ParticipantRole.HOST)
                 .status(ParticipantStatus.APPROVED)
                 .build();
-        mp2 = MeetingParticipant.builder()
+        mp2 = com.bookjuk.domain.participant.MeetingParticipant.builder()
                 .participant(u2)
                 .meeting(m1)
                 .role(ParticipantRole.PARTICIPANT)
                 .status(ParticipantStatus.APPROVED)
                 .build();
-        mp3 = MeetingParticipant.builder()
+        mp3 = com.bookjuk.domain.participant.MeetingParticipant.builder()
                 .participant(u3)
                 .meeting(m1)
                 .role(ParticipantRole.PARTICIPANT)
                 .status(ParticipantStatus.PENDING)
                 .build();
-        mp4 = MeetingParticipant.builder()
+        mp4 = com.bookjuk.domain.participant.MeetingParticipant.builder()
                 .participant(u1)
                 .meeting(m2)
                 .role(ParticipantRole.PARTICIPANT)
                 .status(ParticipantStatus.PENDING)
                 .build();
-        mp5 = MeetingParticipant.builder()
+        mp5 = com.bookjuk.domain.participant.MeetingParticipant.builder()
                 .participant(u2)
                 .meeting(m2)
                 .role(ParticipantRole.HOST)
                 .status(ParticipantStatus.APPROVED)
                 .build();
-        mp6 = MeetingParticipant.builder()
+        mp6 = com.bookjuk.domain.participant.MeetingParticipant.builder()
                 .participant(u2)
                 .meeting(m3)
                 .role(ParticipantRole.HOST)
@@ -269,7 +265,7 @@ class MeetingRepositoryTest {
                 .build();
         meetingRepository.save(m);
 
-        MeetingParticipant mp = MeetingParticipant.builder()
+        com.bookjuk.domain.participant.MeetingParticipant mp = com.bookjuk.domain.participant.MeetingParticipant.builder()
                 .participant(u)
                 .meeting(m)
                 .role(ParticipantRole.PARTICIPANT)
@@ -277,13 +273,13 @@ class MeetingRepositoryTest {
                 .build();
 
         // when
-        MeetingParticipant saved = meetingParticipantRepository.save(mp);
+        com.bookjuk.domain.participant.MeetingParticipant saved = meetingParticipantRepository.save(mp);
         em.flush();
         em.clear();
 
         // then
         assertNotNull(saved.getId());
-        MeetingParticipant found = meetingParticipantRepository.findById(saved.getId()).orElse(null);
+        com.bookjuk.domain.participant.MeetingParticipant found = meetingParticipantRepository.findById(saved.getId()).orElse(null);
         assertNotNull(found);
         assertEquals(u.getId(), found.getParticipant().getId());
         assertEquals(m.getId(), found.getMeeting().getId());
@@ -296,9 +292,9 @@ class MeetingRepositoryTest {
     @DisplayName("기존 참가자의 role을 변경하면 변경 사항이 반영된다.")
     void UpdateRoleTest() {
         // given
-        MeetingParticipant any = meetingParticipants.get(2); // m1의 u3 (PARTICIPANT)
+        com.bookjuk.domain.participant.MeetingParticipant any = meetingParticipants.get(2); // m1의 u3 (PARTICIPANT)
         Long pid = any.getId();
-        MeetingParticipant found = meetingParticipantRepository.findById(pid).orElseThrow();
+        com.bookjuk.domain.participant.MeetingParticipant found = meetingParticipantRepository.findById(pid).orElseThrow();
 
         // when
         found.changeRole(ParticipantRole.HOST);
@@ -306,7 +302,7 @@ class MeetingRepositoryTest {
         em.clear();
 
         // then
-        MeetingParticipant reloaded = meetingParticipantRepository.findById(pid).orElseThrow();
+        com.bookjuk.domain.participant.MeetingParticipant reloaded = meetingParticipantRepository.findById(pid).orElseThrow();
         assertEquals("HOST", reloaded.getRole().toString());
     }
 
@@ -316,7 +312,7 @@ class MeetingRepositoryTest {
     @DisplayName("기존 참가자를 삭제하면 더 이상 조회되지 않는다.")
     void participantDeleteTest() {
         // given
-        MeetingParticipant target = meetingParticipants.get(0);
+        com.bookjuk.domain.participant.MeetingParticipant target = meetingParticipants.get(0);
         Long pid = target.getId();
         assertTrue(meetingParticipantRepository.findById(pid).isPresent());
 

--- a/src/test/java/com/bookjuk/repository/review/MeetingReviewRepositoryTest.java
+++ b/src/test/java/com/bookjuk/repository/review/MeetingReviewRepositoryTest.java
@@ -1,27 +1,7 @@
 package com.bookjuk.repository.review;
 
-import com.bookjuk.domain.meeting.Meeting;
-import com.bookjuk.domain.meeting.MeetingStatus;
-import com.bookjuk.domain.participant.MeetingParticipant;
-import com.bookjuk.domain.participant.ParticipantRole;
-import com.bookjuk.domain.participant.ParticipantStatus;
-import com.bookjuk.domain.review.MeetingReview;
-import com.bookjuk.domain.user.User;
-import com.bookjuk.repository.meeting.MeetingRepository;
-import com.bookjuk.repository.participant.MeetingParticipantRepository;
-import com.bookjuk.repository.user.UserRepository;
-import jakarta.persistence.EntityManager;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional

--- a/src/test/java/com/bookjuk/service/ReviewServiceTest.java
+++ b/src/test/java/com/bookjuk/service/ReviewServiceTest.java
@@ -2,7 +2,6 @@ package com.bookjuk.service;
 
 import com.bookjuk.domain.meeting.Meeting;
 import com.bookjuk.domain.meeting.MeetingStatus;
-import com.bookjuk.domain.participant.MeetingParticipant;
 import com.bookjuk.domain.participant.ParticipantRole;
 import com.bookjuk.domain.participant.ParticipantStatus;
 import com.bookjuk.domain.review.MeetingReview;
@@ -18,14 +17,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.stereotype.Repository;
 import org.springframework.test.annotation.Rollback;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
 @Transactional
@@ -52,9 +48,9 @@ class ReviewServiceTest {
 
     private User u1, u2, u3, u4;
     private Meeting m1, m2, m3;
-    private MeetingParticipant mp1, mp2, mp3, mp4, mp5, mp6;
+    private com.bookjuk.domain.participant.MeetingParticipant mp1, mp2, mp3, mp4, mp5, mp6;
 
-    private List<MeetingParticipant> meetingParticipants;
+    private List<com.bookjuk.domain.participant.MeetingParticipant> meetingParticipants;
 
     @BeforeEach
     void insertBulk() {
@@ -137,37 +133,37 @@ class ReviewServiceTest {
         );
 
         // 참가자 정보 만들기
-        mp1 = MeetingParticipant.builder()
+        mp1 = com.bookjuk.domain.participant.MeetingParticipant.builder()
                 .participant(u1)
                 .meeting(m1)
                 .role(ParticipantRole.HOST)
                 .status(ParticipantStatus.APPROVED)
                 .build();
-        mp2 = MeetingParticipant.builder()
+        mp2 = com.bookjuk.domain.participant.MeetingParticipant.builder()
                 .participant(u2)
                 .meeting(m1)
                 .role(ParticipantRole.PARTICIPANT)
                 .status(ParticipantStatus.APPROVED)
                 .build();
-        mp3 = MeetingParticipant.builder()
+        mp3 = com.bookjuk.domain.participant.MeetingParticipant.builder()
                 .participant(u3)
                 .meeting(m1)
                 .role(ParticipantRole.PARTICIPANT)
                 .status(ParticipantStatus.PENDING)
                 .build();
-        mp4 = MeetingParticipant.builder()
+        mp4 = com.bookjuk.domain.participant.MeetingParticipant.builder()
                 .participant(u1)
                 .meeting(m2)
                 .role(ParticipantRole.PARTICIPANT)
                 .status(ParticipantStatus.PENDING)
                 .build();
-        mp5 = MeetingParticipant.builder()
+        mp5 = com.bookjuk.domain.participant.MeetingParticipant.builder()
                 .participant(u2)
                 .meeting(m2)
                 .role(ParticipantRole.HOST)
                 .status(ParticipantStatus.APPROVED)
                 .build();
-        mp6 = MeetingParticipant.builder()
+        mp6 = com.bookjuk.domain.participant.MeetingParticipant.builder()
                 .participant(u2)
                 .meeting(m3)
                 .role(ParticipantRole.HOST)


### PR DESCRIPTION
### 개요
- MeetingParticipantCustomRepository의 파일명을 MeetingParticipantCustom으로 변경하고,
- MeetingParticipantRepository에 extends MeetingParticipantCustom을 추가하여
- ReviewService에서 커스텀 메서드를 정상적으로 호출할 수 있도록 수정했습니다.

### 주요 변경 사항
1. 파일/클래스명 변경
 - MeetingParticipantCustomRepository → MeetingParticipantCustom
 - 불필요한 Repository 접미어 제거하여 명확한 네이밍 반영

2. Repository 수정
 - MeetingParticipantRepository가 MeetingParticipantCustom을 상속하도록 변경
 - 커스텀 메서드 접근 가능하도록 구조 개선

3. 문제 해결
 - ReviewService에서 MeetingParticipantImpl 메서드를 인식하지 못하던 문제 해결
   → 원인: Repository에서 Custom Interface를 상속하지 않아 구현체 매핑 불가

### 체크리스트
 - [ x ] 클래스 및 파일명 변경
 - [ x ] Repository 인터페이스 상속 수정
 - [ x ]  커스텀 메서드 호출 문제 해결
 - [ x ]  로컬 및 테스트 환경 검증 완료


###테스트 내역
- @SpringBootTest 기반 통합 테스트 진행
- ReviewService에서 커스텀 메서드 호출 정상 동작 확인
- 기존 기능 영향 없음