### PR TITLE
bug: MeetingParticipantCustom 이름 변경 및 Repository 수정

### DIFF
--- a/src/main/java/com/bookjuk/repository/participant/MeetingParticipantCustom.java
+++ b/src/main/java/com/bookjuk/repository/participant/MeetingParticipantCustom.java
@@ -3,9 +3,8 @@ package com.bookjuk.repository.participant;
 import com.bookjuk.domain.user.User;
 
 import java.util.List;
-import java.util.Optional;
 
-public interface MeetingParticipantCustomRepository {
+public interface MeetingParticipantCustom {
 
     // 미팅 id로 미팅 참여자 찾기
     List<User> findMeetingParticipantsByMeetingId(Long id);

--- a/src/main/java/com/bookjuk/repository/participant/MeetingParticipantRepository.java
+++ b/src/main/java/com/bookjuk/repository/participant/MeetingParticipantRepository.java
@@ -3,16 +3,15 @@ package com.bookjuk.repository.participant;
 import com.bookjuk.domain.participant.MeetingParticipant;
 import com.bookjuk.domain.participant.ParticipantRole;
 import com.bookjuk.domain.participant.ParticipantStatus;
-import com.bookjuk.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import java.util.List;
+
 import java.util.Optional;
 
 @Repository
-public interface MeetingParticipantRepository extends JpaRepository<MeetingParticipant, Long> {
+public interface MeetingParticipantRepository extends JpaRepository<MeetingParticipant, Long>, MeetingParticipantCustom {
 
     // 파생 쿼리: 연관관계 경로를 정확히 기술 (Meeting.id / User.id)
     boolean existsByMeeting_IdAndParticipant_IdAndStatus(

--- a/src/main/java/com/bookjuk/repository/participant/MeetingParticipantRepositoryImpl.java
+++ b/src/main/java/com/bookjuk/repository/participant/MeetingParticipantRepositoryImpl.java
@@ -10,7 +10,7 @@ import static com.bookjuk.domain.participant.QMeetingParticipant.meetingParticip
 
 
 @RequiredArgsConstructor
-public class MeetingParticipantRepositoryImpl implements MeetingParticipantCustomRepository{
+public class MeetingParticipantRepositoryImpl implements MeetingParticipantCustom {
 
     // queryDsl을 사용하기 위한 의존객체
     private final JPAQueryFactory factory;

--- a/src/main/java/com/bookjuk/repository/review/MeetingReviewCustom.java
+++ b/src/main/java/com/bookjuk/repository/review/MeetingReviewCustom.java
@@ -3,7 +3,7 @@ package com.bookjuk.repository.review;
 import com.bookjuk.domain.meeting.Meeting;
 import com.bookjuk.domain.user.User;
 
-public interface MeetingReviewCustomRepository {
+public interface MeetingReviewCustom {
 
     // 한 미팅에서 좋아요가 중복인지 체크
     boolean existDuplicateReview(Meeting meeting, User reviewer, User reviewee);

--- a/src/main/java/com/bookjuk/repository/review/MeetingReviewRepository.java
+++ b/src/main/java/com/bookjuk/repository/review/MeetingReviewRepository.java
@@ -1,11 +1,9 @@
 package com.bookjuk.repository.review;
 
 import com.bookjuk.domain.review.MeetingReview;
-import com.bookjuk.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 
-public interface MeetingReviewRepository extends JpaRepository<MeetingReview, Long>, MeetingReviewCustomRepository {
+public interface MeetingReviewRepository extends JpaRepository<MeetingReview, Long>, MeetingReviewCustom {
 
 }
 

--- a/src/main/java/com/bookjuk/repository/review/MeetingReviewRepositoryImpl.java
+++ b/src/main/java/com/bookjuk/repository/review/MeetingReviewRepositoryImpl.java
@@ -1,18 +1,14 @@
 package com.bookjuk.repository.review;
 
 import com.bookjuk.domain.meeting.Meeting;
-import com.bookjuk.domain.review.QMeetingReview;
 import com.bookjuk.domain.user.User;
-import com.bookjuk.repository.participant.MeetingParticipantCustomRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
-
-import java.util.List;
 
 import static com.bookjuk.domain.review.QMeetingReview.meetingReview;
 
 @RequiredArgsConstructor
-public class MeetingReviewRepositoryImpl implements MeetingReviewCustomRepository {
+public class MeetingReviewRepositoryImpl implements MeetingReviewCustom {
 
     // queryDsl을 사용하기 위한 의존객체
     private final JPAQueryFactory factory;

--- a/src/main/java/com/bookjuk/service/ReviewService.java
+++ b/src/main/java/com/bookjuk/service/ReviewService.java
@@ -25,6 +25,7 @@ import static com.bookjuk.domain.meeting.MeetingStatus.COMPLETED;
 
 @RequiredArgsConstructor
 @Service
+@Transactional
 @Slf4j
 public class ReviewService {
 


### PR DESCRIPTION
## 개요
- MeetingParticipantCustomRepository → MeetingParticipantCustom
- MeetingReviewCustomRepository → MeetingReviewCustom 파일명 변경했습니다.
- meeting, meetingparticipant 테스트에 사용된 user entity 와 repository 를 수정, 작성하였습니다.
- ReviewService에 연관관계, JPA 사용을 위해 @Transactional 어노테이션을 추가했습니다.

## 변경 사항
1. 클래스/파일명 변경
 - MeetingParticipantCustomRepository.java → MeetingParticipantCustom.java
 - Repository 접미어를 제거하여 의미를 명확히 하고, Custom Interface 네이밍 컨벤션을 반영

2. Repository 인터페이스 수정
- MeetingParticipantRepository 에 public interface MeetingParticipantRepository extends JpaRepository<MeetingParticipant, Long>, MeetingParticipantCustom { }로 변경하여 커스텀 메서드 접근 가능하도록 함

3. 메서드 접근 문제 해결
- ReviewService에서 MeetingParticipantImpl 커스텀 메서드 호출 시 인식되지 않는 문제 원인 확인
→ 원인: MeetingParticipantRepository가 MeetingParticipantCustom을 상속하지 않아 구현체(MeetingParticipantImpl) 연결이 되지 않음
- 해결: 위와 같이 extends MeetingParticipantCustom 추가 후 정상 동작 확인

## 테스트 방법
- 로컬에서 직접 테스트 메서드를 작성하여 테스트
- TDD(given-when-then) 스타일로 MeetingRepository, MeetingParticipantRepository, MeetingReviewRepository, MeetingReviewService를 JPA를 이용하여 간단한 CRUD 테스트를 진행

## 관련 이슈
- Resolves #42
