### PR TITLE
feat: 마이페이지 정보 응답 dto 생성

### DIFF
--- a/src/main/java/com/bookjuk/dto/mypage/MeetingInfoDto.java
+++ b/src/main/java/com/bookjuk/dto/mypage/MeetingInfoDto.java
@@ -1,0 +1,51 @@
+package com.bookjuk.dto.mypage;
+
+import com.bookjuk.domain.meeting.Meeting;
+import com.bookjuk.domain.meeting.MeetingStatus;
+import com.bookjuk.domain.participant.MeetingParticipant;
+import com.bookjuk.domain.participant.ParticipantRole;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 마이페이지 API 응답을 위한 모임 정보 DTO 클래스
+ *
+ * 사용자가 참여한 모임 정보를 포함합니다.
+ *
+ */
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class MeetingInfoDto {
+
+    // 모임 정보
+    private String meetingTitle;
+    private LocalDateTime meetingTime;
+    private MeetingStatus meetingStatus;
+    private ParticipantRole role;
+    private Map<String, String> book;
+
+    public static MeetingInfoDto from(MeetingParticipant meetingParticipant) {
+        Meeting meeting = meetingParticipant.getMeeting();
+
+        Map<String, String> bookMap = new HashMap<>();
+        bookMap.put("title", meeting.getBookTitle());
+        bookMap.put("author", meeting.getBookAuthor());
+
+        return MeetingInfoDto.builder()
+                .meetingTitle(meeting.getTitle())
+                .meetingTime(meeting.getMeetingTime())
+                .meetingStatus(meeting.getMeetingStatus())
+                .role(meetingParticipant.getRole())
+                .book(bookMap)
+                .build();
+
+    }
+}

--- a/src/main/java/com/bookjuk/dto/mypage/MyPageResponse.java
+++ b/src/main/java/com/bookjuk/dto/mypage/MyPageResponse.java
@@ -1,0 +1,44 @@
+package com.bookjuk.dto.mypage;
+
+import com.bookjuk.domain.meeting.Meeting;
+import com.bookjuk.domain.meeting.MeetingStatus;
+import com.bookjuk.domain.participant.MeetingParticipant;
+import com.bookjuk.domain.participant.ParticipantRole;
+import com.bookjuk.domain.user.User;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 마이페이지 API 응답을 위한 DTO 클래스
+ *
+ * 사용자의 프로필 정보, 통계 정보, 참여한 미팅 목록을 포함합니다.
+ *
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MyPageResponse {
+
+
+    private UserInfoDto profile;
+    private StaticsInfoDto statistics;
+    private List<MeetingInfoDto> meetings;
+
+
+    // 마이페이지 응답 dto로 바꾸는 정적 팩토리 메소드
+    public static MyPageResponse of(UserInfoDto profile, StaticsInfoDto statistics, List<MeetingInfoDto> meeting) {
+
+        return MyPageResponse.builder()
+                .profile(profile)
+                .statistics(statistics)
+                .meetings(meeting)
+                .build();
+    }
+}
+

--- a/src/main/java/com/bookjuk/dto/mypage/StaticsInfoDto.java
+++ b/src/main/java/com/bookjuk/dto/mypage/StaticsInfoDto.java
@@ -1,0 +1,30 @@
+package com.bookjuk.dto.mypage;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 마이페이지 API 응답을 위한 통계 정보 DTO 클래스
+ *
+ * 사용자의 좋아요(리뷰), 참여 모임 개수 정보를 포함합니다.
+ *
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class StaticsInfoDto {
+
+    private int receivedLikes;
+    private int participatedMeeting;
+
+    public static StaticsInfoDto of(int likes, int meetings) {
+        return StaticsInfoDto.builder()
+                .receivedLikes(likes)
+                .participatedMeeting(meetings)
+                .build();
+    }
+
+}

--- a/src/main/java/com/bookjuk/dto/mypage/UserInfoDto.java
+++ b/src/main/java/com/bookjuk/dto/mypage/UserInfoDto.java
@@ -1,0 +1,38 @@
+package com.bookjuk.dto.mypage;
+
+import com.bookjuk.domain.user.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+/**
+ * 마이페이지 API 응답을 위한 사용자 프로필 정보 DTO 클래스
+ *
+ * 사용자의 이름, 이메일, 프로필이미지, 선호장르, 자기소개 목록을 포함합니다.
+ *
+ */
+public class UserInfoDto {
+
+    // 유저 정보
+    private String username;
+    private String email;
+    private String profileImage;
+    private String preferredGenre;
+    private String introduction;
+
+    // 유저 객체를 MyPage 최상위 응답 dto로 보내기 위한 중간 정적 팩토리 메소드
+    public static UserInfoDto from(User user) {
+        return UserInfoDto.builder()
+                .username(user.getUsername())
+                .email(user.getEmail())
+                .profileImage(user.getProfileImage())
+                .preferredGenre(user.getPreferredGenre())
+                .introduction(user.getIntroduction())
+                .build();
+    }
+}

--- a/src/main/java/com/bookjuk/service/MyPageService.java
+++ b/src/main/java/com/bookjuk/service/MyPageService.java
@@ -1,0 +1,23 @@
+package com.bookjuk.service;
+
+import com.bookjuk.repository.meeting.MeetingRepository;
+import com.bookjuk.repository.participant.MeetingParticipantRepository;
+import com.bookjuk.repository.review.MeetingReviewRepository;
+import com.bookjuk.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class MyPageService {
+
+    // 의존 객체 주입
+    private final UserRepository userRepository;
+    private final MeetingRepository meetingRepository;
+    private final MeetingReviewRepository meetingReviewRepository;
+    private final MeetingParticipantRepository meetingParticipantRepository;
+
+    public void viewMyPage() {
+
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,7 @@ logging:
   level:
     org.springframework: info
 
+
 server:
   port: 9000
 
@@ -42,3 +43,7 @@ jwt:
   # 토큰 만료 시간 (밀리초 단위)
   # 24시간: 24 * 60 * 60 * 1000 = 86400000
   expiration: 86400000
+
+file:
+  upload:
+    location: ${user.home}/spring/upload


### PR DESCRIPTION
## 개요
- Mypage 기능 구현에 필요한 dto 를 생성했습니다.

## 변경 사항
- dto 코드가 새롭게 작성되었습니다.

MyPage Api 응답 dto 구조
ApiResponse 
  └─ MyPageResponse   
         ├─ UserInfoDto(프로필 정보)
         ├─ StaticsInfoDto(좋아요, 참여 모임 개수 통계 정보)
         └─ MeetingInfoDto(참여 모임 정보)

## 테스트 방법
- service 구현 완료 후 테스트 예정

## 관련 이슈
- Resolves #48 