### PR TITLE
feat: #30 모임 리스트 조회 API, Controller, Service, DTO 작성

### DIFF
--- a/src/main/java/com/bookjuk/controller/MeetingController.java
+++ b/src/main/java/com/bookjuk/controller/MeetingController.java
@@ -1,12 +1,19 @@
 package com.bookjuk.controller;
 
 import com.bookjuk.domain.user.User;
+import com.bookjuk.dto.common.ApiResponse;
 import com.bookjuk.dto.meeting.MeetingCreateRequest;
 import com.bookjuk.dto.meeting.MeetingDetailResponse;
+import com.bookjuk.dto.meeting.request.MeetingListItemDto;
+import com.bookjuk.dto.meeting.request.MeetingListSearchRequest;
+import com.bookjuk.dto.meeting.response.MeetingListResponse;
+import com.bookjuk.repository.meeting.custom.MeetingRepositoryCustom;
 import com.bookjuk.service.MeetingService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
@@ -52,6 +59,27 @@ public class MeetingController {
 
         log.info("모임 생성 완료 - ID: {}", response.getMeetingId());
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 모임 목록 조회 API (동적 쿼리)
+     * GET /api/meetings
+     */
+    @GetMapping("/api/meetings")
+    public ResponseEntity<?> getMeetings(MeetingListSearchRequest request) {
+        log.info("모임 목록 조회 API 호출 - 페이지: {}, 크기: {}");
+
+        // 요청 → 검색조건 + 페이지로 변환
+        MeetingRepositoryCustom.MeetingSearchCondition condition = request.toCondition();
+        Pageable pageable = PageRequest.of(request.getPage(), request.getSize());
+
+        // 서비스 호출 (MeetingListResponse)
+        MeetingListResponse response = meetingService.getMeetingList(condition, pageable);
+
+        // 공통 응답 포맷으로 감싸기
+        return ResponseEntity.ok(
+                ApiResponse.success("모임 정보 목록이 조회되었습니다.", response)
+        );
     }
 
     /**

--- a/src/main/java/com/bookjuk/domain/meeting/Meeting.java
+++ b/src/main/java/com/bookjuk/domain/meeting/Meeting.java
@@ -16,29 +16,23 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Meeting 클래스는 독서 모임에 대한 정보를 나타내는 엔티티로, 모임의 기본 정보와 관련 데이터들을 포함한다.
- * 이 클래스는 JPA를 사용하여 데이터베이스와 매핑되고, 모임과 관련된 다양한 속성을 제공한다.
+ * Meeting 클래스는 사용자가 생성한 독서 모임 정보를 관리하는 엔티티입니다.
+ * 모임의 제목, 설명, 선정 도서 정보, 장소, 모임 시간, 최대 참여 인원, 현재 상태 등을 포함합니다.
+ * 또한 주최자 정보와 연관된 참가자 리스트를 포함하며, 데이터베이스의 "meeting" 테이블과 매핑됩니다.
+ * 불변성을 유지하기 위해 기본 생성자는 protected로 제한되어 있습니다.
  *
- * 주요 속성:
- * - id: 모임의 고유 식별자
- * - user: 모임의 방장(주최자) 정보를 포함하는 User 엔티티와의 연관 관계
- * - title: 모임의 제목
- * - description: 모임의 상세 설명
- * - imageUrl: 대표 이미지 URL
- * - bookTitle: 모임에서 선정한 도서의 제목
- * - bookAuthor: 모임에서 선정한 도서의 저자
- * - genre: 모임 장르(도서 장르 등)
- * - meetingTime: 모임 시간
- * - location: 모임 장소
- * - maxParticipants: 모임 최대 참여 인원
- * - status: 모임 상태 (RECRUITING, COMPLETED, CANCELLED)
- * - createdAt: 모임 생성 시간 (자동 생성)
- * - updatedAt: 모임 정보 수정 시간 (자동 업데이트)
+ * 주요 기능:
+ * - 모임 생성 시 필요한 데이터를 설정할 수 있습니다.
+ * - 모임 정보 변경을 위한 도메인 메서드 및 업데이트 메서드를 제공합니다.
  *
- * 이 클래스는 lombok 라이브러리를 활용하여 getter 메서드, equals, hashCode, toString 메서드를 자동으로 생성한다.
- * 불변성을 유지하기 위해 기본 생성자는 protected로 제한되어 있으며, 빌더 패턴을 지원하도록 설계될 수 있다.
+ * 제약 사항:
+ * - 모임의 최대 참여 인원(maxParticipants)은 10명을 초과할 수 없습니다.
+ * - 모임의 상태는 모집 중(RECRUITING), 종료(COMPLETED), 취소됨(CANCELLED) 중 하나여야 합니다.
+ *
+ * 연관 관계:
+ * - 다대일 관계로 주최자(User)와 연관됩니다.
+ * - 일대다 관계로 참가자 리스트(MeetingParticipant)와 연관됩니다.
  */
-
 @Entity
 @Table(name = "meeting")
 @Getter
@@ -84,7 +78,7 @@ public class Meeting {
     @Comment("선정 도서 저자")
     private String bookAuthor;
 
-    @Column(name = "genre", length = 100)
+    @Column(name = "genre", nullable = false, length = 100)
     @Comment("모임 장르")
     private String genre;
 
@@ -98,8 +92,12 @@ public class Meeting {
     private String region;
 
     @Column(name = "city", nullable = false, length = 30)
-    @Comment("시/구/군")
+    @Comment("시/군")
     private String city;
+
+    @Column(name = "district", nullable = false, length = 30)
+    @Comment("구/군")
+    private String district;
 
     @Column(name = "detail_address", length = 255)
     @Comment("상세주소(선택)")
@@ -143,6 +141,7 @@ public class Meeting {
                    LocalDateTime meetingTime,
                    String region,
                    String city,
+                   String district,
                    String detailAddress,
                    Integer maxParticipants,
                    MeetingStatus meetingStatus) {
@@ -156,6 +155,7 @@ public class Meeting {
         this.meetingTime = meetingTime;
         this.region = region;
         this.city = city;
+        this.district = district;
         this.detailAddress = detailAddress;
         this.maxParticipants = maxParticipants;
         this.meetingStatus = meetingStatus;

--- a/src/main/java/com/bookjuk/dto/meeting/MeetingSearchRequest.java
+++ b/src/main/java/com/bookjuk/dto/meeting/MeetingSearchRequest.java
@@ -1,5 +1,7 @@
 package com.bookjuk.dto.meeting;
 
+import com.bookjuk.domain.meeting.MeetingStatus;
+import com.bookjuk.repository.meeting.custom.MeetingRepositoryCustom;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -13,6 +15,39 @@ import lombok.Setter;
 @NoArgsConstructor
 public class MeetingSearchRequest {
 
+    // 필터
+    private String region;
+    private String city;
+    private String genre;
+    private String status; // 대소문자 무관 입력 허용
 
+    // 정렬
+    private String sortBy = "latest"; // latest|deadline|popular
 
+    // 페이징
+    private int page = 0;
+    private int size = 6;
+
+    /**
+     * Repository 검색 조건으로 변환
+     * - status는 Enum 변환 시 오류가 나면 무시(null)
+     */
+    public MeetingRepositoryCustom.MeetingSearchCondition toCondition() {
+        MeetingStatus enumStatus = null;
+        if (status != null && !status.trim().isEmpty()) {
+            try {
+                enumStatus = MeetingStatus.valueOf(status.trim().toUpperCase());
+            } catch (IllegalArgumentException ignore) {
+                // 무시: 잘못된 값은 필터에서 제외
+            }
+        }
+
+        return MeetingRepositoryCustom.MeetingSearchCondition.builder()
+                .status(enumStatus)
+                .region(region)
+                .city(city)
+                .genre(genre)
+                .sortBy(sortBy != null ? sortBy : "latest")
+                .build();
+    }
 }

--- a/src/main/java/com/bookjuk/dto/meeting/MeetingSearchRequest.java
+++ b/src/main/java/com/bookjuk/dto/meeting/MeetingSearchRequest.java
@@ -1,0 +1,18 @@
+package com.bookjuk.dto.meeting;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 모임 목록 조회용 검색 파라미터 DTO
+ * GET /api/meetings의 쿼리 파리미터 바인딩에 사용
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class MeetingSearchRequest {
+
+
+
+}

--- a/src/main/java/com/bookjuk/dto/meeting/request/MeetingListItemDto.java
+++ b/src/main/java/com/bookjuk/dto/meeting/request/MeetingListItemDto.java
@@ -1,0 +1,83 @@
+package com.bookjuk.dto.meeting.request;
+
+import com.bookjuk.domain.meeting.Meeting;
+import com.bookjuk.domain.user.User;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * 모임 목록 전용 응답 DTO
+ * /api/meetings 목록 화면 렌더링에 필요한 정보만 포함
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MeetingListItemDto {
+
+    private Long meetingId;
+
+    @Getter @Builder
+    @AllArgsConstructor @NoArgsConstructor
+    public static class HostSummary {
+        private Long userId;
+        private String username;
+        private String profileImage;
+        private String introduction;
+    }
+
+    private HostSummary host;
+
+    private String title;
+    private String description;
+    private String imageUrl;
+
+    private String bookTitle;
+    private String bookAuthor;
+    private String genre;
+    private LocalDateTime meetingTime;
+
+    private String region;
+    private String city;
+    private String district;
+    private String detailAddress;
+
+    private Integer maxParticipants;
+    private Integer currentParticipants;
+
+    private String status;
+
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static MeetingListItemDto from(Meeting m, int currentParticipants) {
+        User h = m.getHost();
+        HostSummary hostSummary = HostSummary.builder()
+                .userId(h.getId())
+                .username(h.getUsername())
+                .profileImage(h.getProfileImage())
+                .introduction(h.getIntroduction())
+                .build();
+
+        return MeetingListItemDto.builder()
+                .meetingId(m.getId())
+                .host(hostSummary)
+                .title(m.getTitle())
+                .description(m.getDescription())
+                .imageUrl(m.getImageUrl())
+                .bookTitle(m.getBookTitle())
+                .bookAuthor(m.getBookAuthor())
+                .genre(m.getGenre())
+                .meetingTime(m.getMeetingTime())
+                .region(m.getRegion())
+                .city(m.getCity())
+                .detailAddress(m.getDetailAddress())
+                .maxParticipants(m.getMaxParticipants())
+                .currentParticipants(currentParticipants)
+                .status(m.getMeetingStatus().name())
+                .createdAt(m.getCreatedAt())
+                .updatedAt(m.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/bookjuk/dto/meeting/request/MeetingListSearchRequest.java
+++ b/src/main/java/com/bookjuk/dto/meeting/request/MeetingListSearchRequest.java
@@ -1,4 +1,4 @@
-package com.bookjuk.dto.meeting;
+package com.bookjuk.dto.meeting.request;
 
 import com.bookjuk.domain.meeting.MeetingStatus;
 import com.bookjuk.repository.meeting.custom.MeetingRepositoryCustom;
@@ -13,7 +13,7 @@ import lombok.Setter;
 @Getter
 @Setter
 @NoArgsConstructor
-public class MeetingSearchRequest {
+public class MeetingListSearchRequest {
 
     // 필터
     private String region;

--- a/src/main/java/com/bookjuk/dto/meeting/response/MeetingListResponse.java
+++ b/src/main/java/com/bookjuk/dto/meeting/response/MeetingListResponse.java
@@ -1,0 +1,30 @@
+package com.bookjuk.dto.meeting.response;
+
+import com.bookjuk.dto.meeting.request.MeetingListItemDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * MeetingListResponse 클래스는 모임 목록 응답 데이터를 나타낸다.
+ * 페이징 처리된 형태로 모임의 목록과 메타 정보를 포함한다.
+ *
+ * 필드 설명:
+ * - content: 모임 목록 데이터를 담고 있으며, 각 항목은 MeetingListItemDto 객체로 구성된다.
+ * - page: 현재 페이지 번호를 나타낸다.
+ * - size: 페이지당 아이템 개수를 나타낸다.
+ * - totalElements: 전체 데이터의 총 개수를 나타낸다.
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MeetingListResponse {
+    private List<MeetingListItemDto> content;
+    private int page;
+    private int size;
+    private long totalElements;
+}

--- a/src/main/java/com/bookjuk/repository/meeting/custom/MeetingRepositoryCustom.java
+++ b/src/main/java/com/bookjuk/repository/meeting/custom/MeetingRepositoryCustom.java
@@ -24,7 +24,7 @@ public interface MeetingRepositoryCustom {
     class MeetingSearchCondition {
 
         private String region; // 시/도로 검색
-        private String city;   // 시/구/군으로 검색
+        private String city;   // 시/군으로 검색
         private String genre;  // 모임 장르로 검색
 
         // 상태값 ( RECRUITING(모집), COMPLETED(종료), CANCELLED(취소) )

--- a/src/main/java/com/bookjuk/repository/meeting/custom/MeetingRepositoryCustom.java
+++ b/src/main/java/com/bookjuk/repository/meeting/custom/MeetingRepositoryCustom.java
@@ -2,7 +2,6 @@ package com.bookjuk.repository.meeting.custom;
 
 import com.bookjuk.domain.meeting.Meeting;
 import com.bookjuk.domain.meeting.MeetingStatus;
-import com.bookjuk.domain.user.User;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
@@ -13,8 +12,8 @@ import org.springframework.data.domain.Pageable;
  */
 public interface MeetingRepositoryCustom {
 
-    // 동적 쿼리로 검색 조건별 여행 목록 조회 메서드 (페이징 포함)
-    Page<Meeting> getTripList(MeetingSearchCondition condition, Pageable pageable);
+    // 동적 쿼리로 검색 조건별 모임 목록 조회 메서드 (페이징 포함)
+    Page<Meeting> getMeetingList(MeetingSearchCondition condition, Pageable pageable);
 
     /**
      * 모임 검색 조건들을 담는 클래스

--- a/src/main/java/com/bookjuk/repository/meeting/impl/MeetingRepositoryImpl.java
+++ b/src/main/java/com/bookjuk/repository/meeting/impl/MeetingRepositoryImpl.java
@@ -32,7 +32,7 @@ public class MeetingRepositoryImpl implements MeetingRepositoryCustom {
     private final JPAQueryFactory factory;
 
     @Override
-    public Page<Meeting> getTripList(MeetingSearchCondition condition, Pageable pageable) {
+    public Page<Meeting> getMeetingList(MeetingSearchCondition condition, Pageable pageable) {
 
         log.info("\ngetTripList call by QueryDSL");
 

--- a/src/main/java/com/bookjuk/repository/participant/MeetingParticipantRepository.java
+++ b/src/main/java/com/bookjuk/repository/participant/MeetingParticipantRepository.java
@@ -34,4 +34,12 @@ public interface MeetingParticipantRepository extends JpaRepository<MeetingParti
     boolean existsMemberWithAccess(@Param("meetingId") Long meetingId,
                                    @Param("userId") Long userId);
 
+    /**
+     * 주어진 모임 ID를 기반으로 해당 모임에 참여 중인 사용자 수를 반환한다.
+     *
+     * @param meetingId 참여 중인 사용자를 확인할 모임의 ID
+     * @return 해당 모임에 참여 중인 사용자 수
+     */
+    int countByMeetingId(Long meetingId);
+
 }

--- a/src/main/java/com/bookjuk/service/MeetingService.java
+++ b/src/main/java/com/bookjuk/service/MeetingService.java
@@ -7,15 +7,21 @@ import com.bookjuk.domain.participant.ParticipantStatus;
 import com.bookjuk.domain.user.User;
 import com.bookjuk.dto.meeting.MeetingCreateRequest;
 import com.bookjuk.dto.meeting.MeetingDetailResponse;
+import com.bookjuk.dto.meeting.request.MeetingListItemDto;
+import com.bookjuk.dto.meeting.response.MeetingListResponse;
 import com.bookjuk.repository.meeting.MeetingRepository;
+import com.bookjuk.repository.meeting.custom.MeetingRepositoryCustom;
 import com.bookjuk.repository.participant.MeetingParticipantRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -64,6 +70,39 @@ public class MeetingService {
             log.error("모임 생성 실패", e);
             throw new RuntimeException("모임 생성에 실패했습니다.", e);
         }
+    }
+
+
+    /**
+     * 모임 목록 조회 서비스 메서드
+     * @param condition 동적 쿼리용 검색 조건 (지역, 장르, 상태, 정렬 등)
+     * @param pageable  페이지 번호, 페이지 크기, 정렬 조건을 담은 페이징 객체
+     * @return 모임 목록 + 페이징 정보가 담긴 MeetingListResponse
+     */
+    public MeetingListResponse getMeetingList(
+            MeetingRepositoryCustom.MeetingSearchCondition condition,
+            Pageable pageable
+    ) {
+        log.info("모임 목록 조회 - 페이징: {}", pageable);
+
+        // 검색 조건과 페이징 정보로 모임 목록을 조회 (Repository 계층)
+        // - QueryDSL로 동적 조건(where, orderBy 등) 적용
+        Page<Meeting> meetingPage = meetingRepository.getMeetingList(condition, pageable);
+
+        // Meeting 엔티티 리스트(+ 참가자 수)를 MeetingListItemDto 리스트로 변환
+        List<MeetingListItemDto> items = meetingPage.getContent().stream()
+                .map(m -> {
+                    int curr = meetingParticipantRepository.countByMeetingId(m.getId());
+                    return MeetingListItemDto.from(m, curr);
+                })
+                .toList();
+
+        return MeetingListResponse.<MeetingListItemDto>builder()
+                .content(items)
+                .page(pageable.getPageNumber())
+                .size(pageable.getPageSize())
+                .totalElements(meetingPage.getTotalElements())
+                .build();
     }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,6 +31,7 @@ logging:
   level:
     org.springframework: info
 
+
 server:
   port: 9000
 
@@ -42,3 +43,7 @@ jwt:
   # 토큰 만료 시간 (밀리초 단위)
   # 24시간: 24 * 60 * 60 * 1000 = 86400000
   expiration: 86400000
+
+file:
+  upload:
+    location: ${user.home}/spring/upload

--- a/src/test/java/com/bookjuk/repository/meeting/MeetingListTest.java
+++ b/src/test/java/com/bookjuk/repository/meeting/MeetingListTest.java
@@ -102,6 +102,7 @@ public class MeetingListTest {
                 .meetingTime(LocalDateTime.of(2025, 8, 20, 19, 0))
                 .region("경기도")
                 .city("안산시")
+                .district("단원구")
                 .maxParticipants(6)
                 .meetingStatus(MeetingStatus.RECRUITING)
                 .build();
@@ -116,6 +117,7 @@ public class MeetingListTest {
                 .meetingTime(LocalDateTime.of(2025, 8, 18, 19, 0))
                 .region("경기도")
                 .city("안양시")
+                .district("주먹구구")
                 .maxParticipants(8)
                 .meetingStatus(MeetingStatus.COMPLETED)
                 .build();
@@ -130,6 +132,7 @@ public class MeetingListTest {
                 .meetingTime(LocalDateTime.of(2025, 8, 21, 19, 0))
                 .region("경기도")
                 .city("구리시")
+                .district("구구")
                 .maxParticipants(4)
                 .meetingStatus(MeetingStatus.RECRUITING)
                 .build();

--- a/src/test/java/com/bookjuk/repository/meeting/MeetingListTest.java
+++ b/src/test/java/com/bookjuk/repository/meeting/MeetingListTest.java
@@ -230,7 +230,7 @@ public class MeetingListTest {
                 .build();
 
         // when
-        Page<Meeting> meetingPage = meetingRepository.getTripList(condition, pageable);
+        Page<Meeting> meetingPage = meetingRepository.getMeetingList(condition, pageable);
         // 실제 데이터 꺼냄
         List<Meeting> meetingList = meetingPage.getContent();
         // then
@@ -258,7 +258,7 @@ public class MeetingListTest {
                 .build();
 
         // when
-        Page<Meeting> meetingPage = meetingRepository.getTripList(condition, pageable);
+        Page<Meeting> meetingPage = meetingRepository.getMeetingList(condition, pageable);
         // 실제 데이터 꺼냄
         List<Meeting> meetingList = meetingPage.getContent();
         // then


### PR DESCRIPTION
## 개요
- 모임 리스트 조회 API를 구현하기 위한 Controller, Service, 응답 dto, 요청 dto를 작성했습니다.

## 변경 사항
1. MeetingController, MeetingService 작성

2. MeetingListSearchRequest.java 작성
- 클라이언트가 모임 리스트 조회 요청을 보내면 MeetingController에서 MeetingListSearchRequest dto를 이용하여 조건을 받음.

3. MeetingListItemDto, MeetingListResponse 작성
- DB에 접근하여 미팅 목록을 MeetingListItemDto 객체 형태로 작성
- API 맞춰서 내용을 설계하기 위해 MeetingListItemDto 내용에 추가로 내용을 더하여 MeetingListResponse 객체를 생성하고, 공용 응답인 ApiResponse에 담아서 응답함.

## 테스트 방법
- 로컬에서 테스트 데이터 생성 후 포스트맨을 이용하여 테스트
- http://localhost:9000/api/meetings?region=경기도&genre=동화&status=RECRUITING&sort=latest&page=0&size=6

## 관련 이슈
- Resolves #30 
