### PR TITLE
Feat: 게시판(Post,Comment) Entity,Repository, Service, Dto, controller 작성 완료

### DIFF
--- a/src/main/java/com/bookjuk/controller/BoardController.java
+++ b/src/main/java/com/bookjuk/controller/BoardController.java
@@ -1,0 +1,244 @@
+package com.bookjuk.controller;
+
+import com.bookjuk.dto.board.request.CommentCreateRequest;
+import com.bookjuk.dto.board.request.CommentUpdateRequest;
+import com.bookjuk.dto.board.request.PostCreateRequest;
+import com.bookjuk.dto.board.request.PostUpdateRequest;
+import com.bookjuk.dto.board.response.CommentCreateResponse;
+import com.bookjuk.dto.board.response.PostCreateResponse;
+import com.bookjuk.dto.board.response.PostDetailResponse;
+import com.bookjuk.dto.board.response.PostListResponse;
+import com.bookjuk.service.BoardService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * 모임 게시판 관련 REST API를 제공하는 컨트롤러
+ *
+ * 게시글 작성, 수정, 삭제, 목록 조회, 상세 조회
+ * 댓글 작성, 수정 삭제
+ */
+@Slf4j
+@Controller
+@RequestMapping("/api/meetings/{meetingId}/posts")
+@RequiredArgsConstructor
+public class BoardController {
+
+    private final BoardService boardService;
+
+    /**
+     * 특정 모임의 게시글 목록을 페이징하여 조회한다.(기본값: page=1, size=10)
+     *
+     * @param meetingId 모임 ID
+     * @param page 페이지 번호 (기본값: 1)
+     * @param size 페이지 크기 (기본값: 10)
+     * @return 게시글 목록 응답 (200 OK)
+     */
+    @GetMapping   // 페이징 조회는 기본 경로
+    @ResponseBody
+    public ResponseEntity<Page<PostListResponse>> getPostList(
+            @PathVariable Long meetingId,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size) {
+
+        log.info("게시글 목록 조회 요청 - meetingId: {}, page: {}, size: {}", meetingId, page, size);
+
+        Page<PostListResponse> posts = boardService.getPostList(meetingId, page, size);
+
+        log.info("게시글 목록 조회 완료 - meetingId: {}, totalElements: {}", meetingId, posts.getTotalElements());
+
+        return ResponseEntity.ok(posts);
+    }
+
+    /**
+     * 특정 게시글의 상세 정보를 조회한다. (게시글 정보와 모든 댓글)
+     *
+     * @param meetingId 모임 ID
+     * @param postId 게시글 ID
+     * @return 게시글 상세 정보 응답 (200 OK)
+     * @throws com.bookjuk.exception.CustomException 게시글을 찾을 수 없는 경우 (404 Not Found)
+     */
+    @GetMapping("/{postId}")
+    @ResponseBody
+    public ResponseEntity<PostDetailResponse> getPostDetail(
+            @PathVariable Long meetingId,
+            @PathVariable Long postId) {
+
+        log.info("게시글 상세 조회 요청 - meetingId: {}, postId: {}", meetingId, postId);
+
+        PostDetailResponse post = boardService.getPostDetail(meetingId, postId);
+
+        log.info("게시글 상세 조회 완료 - meetingId: {}, postId: {}, commentCount: {}",
+                meetingId, postId, post.getComments().size());
+
+        return ResponseEntity.ok(post);
+    }
+
+    /**
+     * 새로운 게시글을 작성한다.(HOST 또는 APPROVED 상태의 PARTICIPANT만 작성할 수 있다)
+     *
+     * @param meetingId 모임 ID
+     * @param request 게시글 작성 요청 데이터 (유효성 검증 적용)
+     * @param userId JWT에서 추출한 사용자 ID
+     * @return 생성된 게시글 ID 응답 (200 OK)
+     * @throws com.bookjuk.exception.CustomException 작성 권한이 없는 경우 (403 Forbidden)
+     * @throws com.bookjuk.exception.CustomException 입력 데이터가 유효하지 않은 경우 (400 Bad Request)
+     */
+    @PostMapping
+    @ResponseBody
+    public ResponseEntity<PostCreateResponse> createPost(
+            @PathVariable Long meetingId,
+            @Valid @RequestBody PostCreateRequest request,
+            @RequestAttribute("userId") Long userId) {
+
+        log.info("게시글 작성 요청 - meetingId: {}, userId: {}, title: {}", meetingId, userId, request.getTitle());
+
+        Long postId = boardService.createPost(meetingId, userId, request);
+
+        log.info("게시글 작성 완료 - meetingId: {}, userId: {}, postId: {}", meetingId, userId, postId);
+
+        return ResponseEntity.ok(new PostCreateResponse(postId));
+    }
+
+    /**
+     * 기존 게시글을 수정한다. (작성자, 모임의 HOST만 수정 가능)
+     *
+     * @param meetingId 모임 ID
+     * @param postId 게시글 ID
+     * @param request 게시글 수정 데이터 (유효성 검증 적용)
+     * @param userId JWT에서 추출한 사용자 ID
+     * @return 성공 응답 (200 OK)
+     * @throws com.bookjuk.exception.CustomException 게시글을 찾을 수 없거나 수정 권한이 없는 경우
+     */
+    @PutMapping("/{postId}")
+    @ResponseBody
+    public ResponseEntity<Void> updatePost(
+            @PathVariable Long meetingId,
+            @PathVariable Long postId,
+            @Valid @RequestBody PostUpdateRequest request,
+            @RequestAttribute("userId") Long userId) {
+
+        log.info("게시글 수정 요청 - meetingId: {}, postId: {}, userId: {}", meetingId, postId, userId);
+
+        boardService.updatePost(meetingId, postId, userId, request);
+
+        log.info("게시글 수정 완료 - meetingId: {}, postId: {}, userId: {}", meetingId, postId, userId);
+
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 게시글을 삭제한다. (작성자, 모임의 HOST만 가능)
+     * 게시글과 함께 관련된 모든 댓글도 삭제.
+     *
+     * @param meetingId 모임 ID
+     * @param postId 게시글 ID
+     * @param userId JWT에서 추출한 사용자 ID
+     * @return 성공 응답 (200 OK)
+     * @throws com.bookjuk.exception.CustomException 게시글을 찾을 수 없거나 삭제 권한이 없는 경우
+     */
+    @DeleteMapping("/{postId}")
+    @ResponseBody
+    public ResponseEntity<Void> deletePost(
+            @PathVariable Long meetingId,
+            @PathVariable Long postId,
+            @RequestAttribute("userId") Long userId) {
+
+        log.info("게시글 삭제 요청 - meetingId: {}, postId: {}, userId: {}", meetingId, postId, userId);
+
+        boardService.deletePost(meetingId, postId, userId);
+
+        log.info("게시글 삭제 완료 - meetingId: {}, postId: {}, userId: {}", meetingId, postId, userId);
+
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 게시글에 댓글을 작성한다.
+     * HOST 또는 APPROVED 상태의 PARTICIPANT만 작성할 수 있다.
+     *
+     * @param meetingId 모임 ID
+     * @param postId 게시글 ID
+     * @param request 댓글 작성 요청 데이터 (유효성 검증 적용)
+     * @param userId JWT에서 추출한 사용자 ID
+     * @return 생성된 댓글 ID 응답 (200 OK)
+     * @throws com.bookjuk.exception.CustomException 게시글을 찾을 수 없거나 작성 권한이 없는 경우
+     */
+    @PostMapping("/{postId}/comments")
+    @ResponseBody
+    public ResponseEntity<CommentCreateResponse> createComment(
+            @PathVariable Long meetingId,
+            @PathVariable Long postId,
+            @Valid @RequestBody CommentCreateRequest request,
+            @RequestAttribute("userId") Long userId) {
+
+        log.info("댓글 작성 요청 - meetingId: {}, postId: {}, userId: {}", meetingId, postId, userId);
+
+        Long commentId = boardService.createComment(meetingId, postId, userId, request);
+
+        log.info("댓글 작성 완료 - meetingId: {}, postId: {}, userId: {}, commentId: {}", meetingId, postId, userId, commentId);
+
+        return ResponseEntity.ok(new CommentCreateResponse(commentId));
+    }
+
+    /**
+     * 댓글을 수정한다. (작석장, 모임의 HOST만 가능)
+     *
+     * @param meetingId 모임 ID
+     * @param postId 게시글 ID
+     * @param commentId 댓글 ID
+     * @param request 댓글 수정 데이터 (유효성 검증 적용)
+     * @param userId JWT에서 추출한 사용자 ID
+     * @return 성공 응답 (200 OK)
+     * @throws com.bookjuk.exception.CustomException 게시글이나 댓글을 찾을 수 없거나 수정 권한이 없는 경우
+     */
+    @PutMapping("/{postId}/comments/{commentId}")
+    @ResponseBody
+    public ResponseEntity<Void> updateComment(
+            @PathVariable Long meetingId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @Valid @RequestBody CommentUpdateRequest request,
+            @RequestAttribute("userId") Long userId) {
+
+        log.info("댓글 수정 요청 - meetingId: {}, postId: {}, commentId: {}, userId: {}", meetingId, postId, commentId, userId);
+
+        boardService.updateComment(meetingId, postId, commentId, userId, request);
+
+        log.info("댓글 수정 완료 - meetingId: {}, postId: {}, commentId: {}, userId: {}", meetingId, postId, commentId, userId);
+
+        return ResponseEntity.ok().build();
+    }
+
+    /**
+     * 댓글을 삭제한다. (작성자, 모임의 HOST만 가능)
+     *
+     * @param meetingId 모임 ID
+     * @param postId 게시글 ID
+     * @param commentId 댓글 ID
+     * @param userId JWT에서 추출한 사용자 ID
+     * @return 성공 응답 (200 OK)
+     * @throws com.bookjuk.exception.CustomException 게시글이나 댓글을 찾을 수 없거나 삭제 권한이 없는 경우
+     */
+    @DeleteMapping("/{postId}/comments/{commentId}")
+    @ResponseBody
+    public ResponseEntity<Void> deleteComment(
+            @PathVariable Long meetingId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @RequestAttribute("userId") Long userId) {
+
+        log.info("댓글 삭제 요청 - meetingId: {}, postId: {}, commentId: {}, userId: {}", meetingId, postId, commentId, userId);
+
+        boardService.deleteComment(meetingId, postId, commentId, userId);
+
+        log.info("댓글 삭제 완료 - meetingId: {}, postId: {}, commentId: {}, userId: {}", meetingId, postId, commentId, userId);
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/bookjuk/domain/board/Comment.java
+++ b/src/main/java/com/bookjuk/domain/board/Comment.java
@@ -7,6 +7,15 @@ import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 
+
+/**
+ * 게시글에 달린 댓글을 나타내는 엔티티 클래스
+ *
+ * 게시글에는 여러 개의 댓글을 작성할 수 있다.
+ * FK 제약 조건 대신 ID 값으로 관리
+ * 작성, 수정시간 자동 관리
+ * 수정 시 비즈니스 로직 (작성, 수정, 삭제 등)
+ */
 @Entity
 @Table(name = "comment")
 @Getter
@@ -15,27 +24,69 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class Comment {
 
+    // 댓글의 고유 식별자 (자동생성, DDL의 id 컬럼과 1:1 매핑)
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;         // DDL: PK = id
+    private Long id;
 
+    // 댓글이 속한 게시글의 ID (ID 값으로만 관리 FK X) 게시글이 삭제될 때 관련 댓글도 함께 삭제되도록 처리
     @Column(nullable = false)
-    private Long postId;     // 소속 게시글
+    private Long postId;
 
+    // 댓글 작성자의 사용자 ID (실제 사용자 정보는 엔터티에서 별도로 조회) 작성자 정보는 username 필드를 통해 표시
     @Column(nullable = false)
-    private Long userId;     // 작성자
+    private Long userId;
 
+     // 댓글 내용 LOB(Large Object) 타입으로 긴 텍스트를 저장하고 (필수 입력, 빈 값x)
     @Lob
     @Column(nullable = false)
     private String content;
 
+    // 댓글 작성 시간 (저장될 때 시간 자동)
     @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    // 댓글 수정 시간 (업데이트 때 시간 자동)
     @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    /**
+     * 댓글 내용을 수정한다.
+     *
+     * 입력값 유효성 검증(null, 빈 문자열 체크)
+     * 댓글 내용 업데이트
+     *
+     * @param content 새로운 댓글 내용 (null이나 빈 문자열 불가)
+     * @throws IllegalArgumentException content가 null이거나 빈 문자열인 경우
+     */
     public void edit(String content) {
-        this.content = content;
+        if (content == null || content.trim().isEmpty()) {
+            throw new IllegalArgumentException("댓글 내용은 비어있을 수 없습니다.");
+        }
+        this.content = content.trim();
+    }
+
+    /**
+     * 댓글이 특정 사용자에 의해 작성되었는지 확인한다. (댓글 수정,삭제 권한 확인 시)
+     *
+     * @param userId 확인할 사용자 ID
+     * @return 해당 사용자가 작성한 댓글이면 true, 아니면 false
+     */
+    public boolean isWrittenBy(Long userId) {
+        return this.userId != null && this.userId.equals(userId);
+    }
+
+    /**
+     * 댓글이 특정 게시글에 속하는지 확인한다.
+     *
+     * <p>댓글 조회 시 게시글 소속 여부를 확인하기 위해 사용됩니다.
+     *
+     * @param postId 확인할 게시글 ID
+     * @return 해당 게시글에 속한 댓글이면 true, 아니면 false
+     */
+    public boolean belongsToPost(Long postId) {
+        return this.postId != null && this.postId.equals(postId);
     }
 }

--- a/src/main/java/com/bookjuk/domain/board/Post.java
+++ b/src/main/java/com/bookjuk/domain/board/Post.java
@@ -5,8 +5,19 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import javax.swing.text.html.HTML;
 import java.time.LocalDateTime;
 
+/**
+ * 모임 게시판의 게시글을 나타내는 엔터티 클래스
+ *
+ * 특정 모임 게시글 관리
+ * FK 제약 조건 대신 ID 값으로 관리
+ * 제목 최대 200자 제한
+ * 이미지 첨부 가능
+ * 작성 시간과 수정시간 자동관리
+ * 게시글 수정 시 비즈니스 로직 검증 (작성, 수정, 삭제 등)
+ */
 @Entity
 @Table(name = "post")
 @Getter
@@ -15,35 +26,108 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class Post {
 
+
+    // 게시글의 고유 식별자(자동 생성) post_id 컬럼과 1:1매핑
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "post_id") // DDL: post_id 컬럼과 1:1 매핑
+    @Column(name = "post_id")
     private Long postId;
 
+     // 게시글이 속한 모임의 ID (ID 값으로만 관리 FK x), 모임 삭제 시 게시글도 삭제되도록 처리
     @Column(nullable = false)
-    private Long meetingId;     // FK 미사용 정책 → ID 값으로만 소유 관계 유지
+    private Long meetingId;
 
+    // 게시글 작성자의 사용자 ID (실제 정보는 User 엔터티에서 별도로 조회) 작성자는 username 필드를 통해 표시
     @Column(nullable = false)
-    private Long userId;        // 작성자 user_id
+    private Long userId;
 
+    //게시글 제목은 최대 200자까지 허용되며 필수 입력해야한다. (공백x, 앞뒤 공백 자동x)
     @Column(nullable = false, length = 200)
     private String title;
 
+    // 게시글 내용 LOB(Large Object) 타입으로 긴 텍스트를 저장하고 (필수 입력, 빈 값x)
     @Lob
     @Column(nullable = false)
     private String content;
 
+    // 게시글에 첨부된 이미지의 URL 선택적 필드 (URL은 유요한 형식이여야 하고 빈 문자열은 null)
+    @Column(name = "image_url")
     private String imageUrl;
 
+    // 게시글 작성 시간 (저장될 때 시간 자동)
     @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
+    // 게시글 최종 수정 시간 (업데이트 때 시간 자동)
     @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    /**
+     * 게시글 정보를 수정한다
+     *
+     * 유효성 검증 (null, 빈 문자열, 길이 제한 체크)
+     * 게시글 제목, 내용, 이미지URL 업데이트
+     * 공백 정리 (trim 처리)
+     * @param title 새로운 게시글 제목 (1-200자, null이나 빈 문자열 불가)
+     * @param content 새로운 게시글 내용 (null이나 빈 문자열 불가)
+     * @param imageUrl 새로운 이미지 URL (null 허용, 빈 문자열은 null로 처리)
+     * @throws IllegalArgumentException title이나 content가 null이거나 빈 문자열인 경우
+     * @throws IllegalArgumentException title이 200자를 초과하는 경우
+     */
     public void edit(String title, String content, String imageUrl) {
-        this.title = title;
-        this.content = content;
-        this.imageUrl = imageUrl;
+        // 제목 유효성 검증
+        if (title == null || title.trim().isEmpty()) {
+            throw new IllegalArgumentException("게시글 제목은 비어있을 수 없습니다.");
+        }
+        if (title.trim().length() > 200) {
+            throw new IllegalArgumentException("게시글 제목은 200자를 초과할 수 없습니다.");
+        }
+
+        // 내용 유효성 검증
+        if (content == null || content.trim().isEmpty()) {
+            throw new IllegalArgumentException("게시글 내용은 비어있을 수 없습니다.");
+        }
+
+        // 필드 업데이트 (공백 정리)
+        this.title = title.trim();
+        this.content = content.trim();
+
+        // 이미지 URL 처리 (빈 문자열은 null로 변환)
+        if (imageUrl != null && imageUrl.trim().isEmpty()) {
+            this.imageUrl = null;
+        } else {
+            this.imageUrl = imageUrl != null ? imageUrl.trim() : null;
+        }
+    }
+
+    /**
+     * 게시글이 특정 사용자에 의해 작성되었는지 확인한다 (수정,삭제 권한 확인 시 사용)
+     *
+     * @param userId 확인할 사용자 ID
+     * @return 해당 사용자가 작성한 게시글이면 true, 아니면 false
+     */
+    public boolean isWrittenBy(Long userId) {
+        return this.userId != null && this.userId.equals(userId);
+    }
+
+    /**
+     * 게시글이 특정 모임에 속하는지 확인한다 (조회 시 모임 소속 여부 확인)
+     *
+     * @param meetingId 확인할 모임 ID
+     * @return 해당 모임에 속한 게시글이면 true, 아니면 false
+     */
+    public boolean belongsToMeeting(Long meetingId) {
+        return this.meetingId != null && this.meetingId.equals(meetingId);
+    }
+
+    /**
+     * 게시글에 이미지가 첨부되어 있는지 확인한다. (프론트엔드에서 이미지 표시 여부를 결정할 때 사용가능)
+     *
+     * @return 이미지가 첨부되어 있으면 true, 아니면 false
+     */
+    public boolean hasImage() {
+        return this.imageUrl != null && !this.imageUrl.trim().isEmpty();
     }
 }

--- a/src/main/java/com/bookjuk/dto/board/request/CommentCreateRequest.java
+++ b/src/main/java/com/bookjuk/dto/board/request/CommentCreateRequest.java
@@ -1,0 +1,11 @@
+package com.bookjuk.dto.board.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentCreateRequest {
+
+    private String content;
+}

--- a/src/main/java/com/bookjuk/dto/board/request/CommentCreateRequest.java
+++ b/src/main/java/com/bookjuk/dto/board/request/CommentCreateRequest.java
@@ -1,11 +1,20 @@
 package com.bookjuk.dto.board.request;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+
+/**
+ * 댓글 작성(생성) 요청 데이터를 담는 DTO 클래스
+ * 하나의 게시글에는 여러 개의 댓글을 작성할 수 있다.
+ */
 @Getter
 @NoArgsConstructor
 public class CommentCreateRequest {
 
+
+    // 댓글 내용은 HTML 태그는 허용되지 않으며 일반 텍스트로 저장된다.
+    @NotBlank(message = " 댓글 내용은 필수입니다.")
     private String content;
 }

--- a/src/main/java/com/bookjuk/dto/board/request/CommentUpdateRequest.java
+++ b/src/main/java/com/bookjuk/dto/board/request/CommentUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.bookjuk.dto.board.request;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CommentUpdateRequest {
+
+    private String content;
+}

--- a/src/main/java/com/bookjuk/dto/board/request/CommentUpdateRequest.java
+++ b/src/main/java/com/bookjuk/dto/board/request/CommentUpdateRequest.java
@@ -1,12 +1,20 @@
 package com.bookjuk.dto.board.request;
 
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+
+/**
+ * 댓글 수정 요청 데이터를 담는 DTO 클래스
+ * 작성자 또는 모임의 HOST만 수정할 수 있다.
+ */
 @Getter
 @NoArgsConstructor
 public class CommentUpdateRequest {
 
+    // 수정할 댓글 내용은 HTML 태그는 허용되지 않으며 일반 텍스트로 저장된다.
+    @NotBlank(message = "댓글 내용은 필수입니다.")
     private String content;
 }

--- a/src/main/java/com/bookjuk/dto/board/request/PostCreateRequest.java
+++ b/src/main/java/com/bookjuk/dto/board/request/PostCreateRequest.java
@@ -1,13 +1,31 @@
 package com.bookjuk.dto.board.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 게시글 수정 요청 데이터를 담는 DTO 클래스
+ * 작성자 또는 모임의 HOST만 수정할 수 있다.
+ */
 @Getter
 @NoArgsConstructor
 public class PostCreateRequest {
 
+
+    // 수정할 게시글 제목은 공백만으로 구성될 수 없다.(1~200자)
+    @NotBlank(message = "게시글 제목은 필수입니다.")
+    @Size(max = 200, message = "게시글 제목은 200자 이하로 작성해주세요.")
     private String title;
-    private String comment;
+
+
+    //  수정할 게시글 내용은 HTML태그는 허용되지 않으며 일반 텍스트로 저장된다.
+    @NotBlank(message = "게시글 내용은 필수입니다.")
+    private String content;
+
+
+    // 수정할 이미지 URL(Null 허용), 기존 이미지를 삭제하려면 빈 문자열을 전달한다.
     private String imageUrl;
+
 }

--- a/src/main/java/com/bookjuk/dto/board/request/PostCreateRequest.java
+++ b/src/main/java/com/bookjuk/dto/board/request/PostCreateRequest.java
@@ -1,0 +1,13 @@
+package com.bookjuk.dto.board.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostCreateRequest {
+
+    private String title;
+    private String comment;
+    private String imageUrl;
+}

--- a/src/main/java/com/bookjuk/dto/board/request/PostUpdateRequest.java
+++ b/src/main/java/com/bookjuk/dto/board/request/PostUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.bookjuk.dto.board.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostUpdateRequest {
+
+    private String title;
+    private String content;
+    private String imageUrl;
+}

--- a/src/main/java/com/bookjuk/dto/board/request/PostUpdateRequest.java
+++ b/src/main/java/com/bookjuk/dto/board/request/PostUpdateRequest.java
@@ -1,13 +1,28 @@
 package com.bookjuk.dto.board.request;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 게시글 작성(생성) 요청 데이터를 담는 DTO 클래스
+ * 제목과 내용은 필수값이며, 유효성 검증이 적용된다.
+ */
 @Getter
 @NoArgsConstructor
 public class PostUpdateRequest {
 
+    // 게시글 제목은 공백만으로 구성 될 수 없다. 1자 이상 200자 이하
+    @NotBlank(message = "게시글 제목은 필수입니다.")
+    @Size(max = 200, message = "게시글 제목은 200자 이하로 작성해주세요.")
     private String title;
+
+    // 게시글 내용은 HTML태그는 허용되지 않으며 일반 텍스트로 저장된다.
+    @NotBlank(message = "게시글 내용은 필수입니다.")
     private String content;
+
+    // 게시글에 첨부할 이미지 URL( null 값 허용)
     private String imageUrl;
+
 }

--- a/src/main/java/com/bookjuk/dto/board/response/CommentCreateResponse.java
+++ b/src/main/java/com/bookjuk/dto/board/response/CommentCreateResponse.java
@@ -9,7 +9,7 @@ import lombok.Getter;
  */
 @Getter
 @AllArgsConstructor
-public class CommentCreatedResponse {
+public class CommentCreateResponse {
 
     // 새로 생성된 댓글의 고유 식별자(클라이언트는 이 ID를 사용하여 생성된 게시글에 접근할 수 있다.)
     private Long commentId;

--- a/src/main/java/com/bookjuk/dto/board/response/CommentCreatedResponse.java
+++ b/src/main/java/com/bookjuk/dto/board/response/CommentCreatedResponse.java
@@ -1,0 +1,11 @@
+package com.bookjuk.dto.board.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CommentCreatedResponse {
+
+    private Long commentId;
+}

--- a/src/main/java/com/bookjuk/dto/board/response/CommentCreatedResponse.java
+++ b/src/main/java/com/bookjuk/dto/board/response/CommentCreatedResponse.java
@@ -3,9 +3,14 @@ package com.bookjuk.dto.board.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * 댓글 작성 시(성공) 반환되는 응답 DTO 클래스
+ * 새로 생성된 댓글의 ID를 클라이언트에게 전달한다.
+ */
 @Getter
 @AllArgsConstructor
 public class CommentCreatedResponse {
 
+    // 새로 생성된 댓글의 고유 식별자(클라이언트는 이 ID를 사용하여 생성된 게시글에 접근할 수 있다.)
     private Long commentId;
 }

--- a/src/main/java/com/bookjuk/dto/board/response/CommentResponse.java
+++ b/src/main/java/com/bookjuk/dto/board/response/CommentResponse.java
@@ -1,0 +1,30 @@
+package com.bookjuk.dto.board.response;
+
+
+import com.bookjuk.domain.board.Comment;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class CommentResponse {
+
+    private Long commentId;
+    private String content;
+    private Long userId;
+    private String username;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static CommentResponse from(Comment comment) {
+        return CommentResponse.builder()
+                .commentId(comment.getId())
+                .content(comment.getContent())
+                .userId(comment.getUserId())
+                .createdAt(comment.getCreatedAt())
+                .updatedAt(comment.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/bookjuk/dto/board/response/CommentResponse.java
+++ b/src/main/java/com/bookjuk/dto/board/response/CommentResponse.java
@@ -7,18 +7,37 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+
+/**
+ * 댓글 정보를 담는 응답 DTO 클래스
+ * 댓글 작성자의 username도 함께 포함된다.
+ */
 @Getter
 @Builder
 public class CommentResponse {
 
+    // 댓글 고유 식별자
     private Long commentId;
+    // 댓글 내용
     private String content;
+    // 댓글 작성자 ID
     private Long userId;
+    // 댓글 작성자명
     private String username;
+    // 댓글 작성 시간
     private LocalDateTime createdAt;
+    // 댓글 수정 시간
     private LocalDateTime updatedAt;
 
-    public static CommentResponse from(Comment comment) {
+
+    /**
+     * 엔터티와 작성자로부터 CommentResponse 객체를 생성한다.
+     *
+     * @param comment 댓글 엔터티
+     * @param username 작성자 사용자명
+     * @return CommentResponse 객체
+     */
+    public static CommentResponse from(Comment comment, String username) {
         return CommentResponse.builder()
                 .commentId(comment.getId())
                 .content(comment.getContent())

--- a/src/main/java/com/bookjuk/dto/board/response/PostCreateResponse.java
+++ b/src/main/java/com/bookjuk/dto/board/response/PostCreateResponse.java
@@ -3,9 +3,14 @@ package com.bookjuk.dto.board.response;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * 게시글 작성 성공 시 반환되는 응답 DTO 클래스
+ * 새로 생성된 게시글의 ID를 클라이언트에게 전달한다.
+ */
 @Getter
 @AllArgsConstructor
 public class PostCreateResponse {
 
+    // 새로 생성된 게시글의 고유 식별자 (클라이언트는 이 ID를 사용하여 생성된 게시글에 접근할 수 있다.)
     private Long postId;
 }

--- a/src/main/java/com/bookjuk/dto/board/response/PostCreateResponse.java
+++ b/src/main/java/com/bookjuk/dto/board/response/PostCreateResponse.java
@@ -1,0 +1,11 @@
+package com.bookjuk.dto.board.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PostCreateResponse {
+
+    private Long postId;
+}

--- a/src/main/java/com/bookjuk/dto/board/response/PostDetailResponse.java
+++ b/src/main/java/com/bookjuk/dto/board/response/PostDetailResponse.java
@@ -5,29 +5,56 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
+
+/**
+ * 게시글 상세 조회 시 반환되는 응답 DTO 클래스
+ * 댓글 목록도 포함되며 작성자의 username도 제공된다.
+ */
 @Getter
 @Builder
 public class PostDetailResponse {
 
+    // 게시글 고유 식별자
     private Long postId;
+    // 게시글 제목
     private String title;
+    // 게시글 내용
     private String content;
+    // 게시글 이미지 URL (NULL 가능)
     private String imageUrl;
+    // 게시글 작성자 ID
     private Long userId;
+    // 게시글 작성자명 (사용자를 찾을 수 없는 경우 "알 수 없는 사용자"로 표시된다.)
     private String username;
+    // 작성 시간
     private LocalDateTime createdAt;
+    // 수정 시간
     private LocalDateTime updatedAt;
+    // 게시글에 달린 댓글 목록( 없는 경우 빈 리스트반환)
+    private List<CommentResponse> comments;
 
-    public static PostListResponse from(Post post) {
-        return PostListResponse.builder()
+
+    /**
+     * 엔터티, 작성자, 댓글 목록으로부터 객체를 생성합니다.
+     *
+     * @param post 게시글 엔터티
+     * @param username 작성자명
+     * @param comments 댓글 응답 DTO 리스트
+     * @return PostDetailResponse 객체
+     */
+    public static PostDetailResponse from(Post post, String username, List<CommentResponse> comments) {
+        return PostDetailResponse.builder()
                 .postId(post.getPostId())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .imageUrl(post.getImageUrl())
                 .userId(post.getUserId())
+                .username(username)
                 .createdAt(post.getCreatedAt())
-                .updateAt(post.getUpdatedAt())
+                .updatedAt(post.getUpdatedAt())
+                .comments(comments)
                 .build();
     }
 

--- a/src/main/java/com/bookjuk/dto/board/response/PostDetailResponse.java
+++ b/src/main/java/com/bookjuk/dto/board/response/PostDetailResponse.java
@@ -1,0 +1,34 @@
+package com.bookjuk.dto.board.response;
+
+import com.bookjuk.domain.board.Post;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PostDetailResponse {
+
+    private Long postId;
+    private String title;
+    private String content;
+    private String imageUrl;
+    private Long userId;
+    private String username;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static PostListResponse from(Post post) {
+        return PostListResponse.builder()
+                .postId(post.getPostId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .imageUrl(post.getImageUrl())
+                .userId(post.getUserId())
+                .createdAt(post.getCreatedAt())
+                .updateAt(post.getUpdatedAt())
+                .build();
+    }
+
+}

--- a/src/main/java/com/bookjuk/dto/board/response/PostListResponse.java
+++ b/src/main/java/com/bookjuk/dto/board/response/PostListResponse.java
@@ -6,28 +6,50 @@ import lombok.Getter;
 
 import java.time.LocalDateTime;
 
+
+/**
+ * 게시글 목록 조회 시 반환되는 응답 DTO 클래스
+ * 작성자의 username도 함께 포함된다.
+ */
 @Getter
 @Builder
 public class PostListResponse {
 
+    // 게시글 고유 식별자
     private Long postId;
+    // 게시글 제목
     private String title;
+    // 게시글 내용
     private String content;
+    // 게시글 이미지 URL
     private String imageUrl;
+    // 게시글 작성자 ID
     private Long userId;
+    // 게시글 작성자명 (사용자를 찾을 수 없는 경우 "알 수 없는 사용자"로 표시된다)
     private String username;
+    // 게시글 작성 시간
     private LocalDateTime createdAt;
-    private LocalDateTime updateAt;
+    // 게시글 수정 시간
+    private LocalDateTime updatedAt;
 
-    public static PostListResponse from(Post post) {
+
+    /**
+     * Post 엔터티와 작성자 username 으로부터 PostListResponse 객체를 생성한다.
+     * @param post 게시글 엔터티
+     * @param username 작성자명
+     * @return PostListResponse 객체
+     */
+    public static PostListResponse from(Post post, String username) {
         return PostListResponse.builder()
                 .postId(post.getPostId())
                 .title(post.getTitle())
                 .content(post.getContent())
                 .imageUrl(post.getImageUrl())
                 .userId(post.getUserId())
+                .username(username)
                 .createdAt(post.getCreatedAt())
-                .updateAt(post.getUpdatedAt())
+                .updatedAt(post.getUpdatedAt())
                 .build();
     }
+
 }

--- a/src/main/java/com/bookjuk/dto/board/response/PostListResponse.java
+++ b/src/main/java/com/bookjuk/dto/board/response/PostListResponse.java
@@ -1,0 +1,33 @@
+package com.bookjuk.dto.board.response;
+
+import com.bookjuk.domain.board.Post;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class PostListResponse {
+
+    private Long postId;
+    private String title;
+    private String content;
+    private String imageUrl;
+    private Long userId;
+    private String username;
+    private LocalDateTime createdAt;
+    private LocalDateTime updateAt;
+
+    public static PostListResponse from(Post post) {
+        return PostListResponse.builder()
+                .postId(post.getPostId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .imageUrl(post.getImageUrl())
+                .userId(post.getUserId())
+                .createdAt(post.getCreatedAt())
+                .updateAt(post.getUpdatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/bookjuk/exception/ErrorCode.java
+++ b/src/main/java/com/bookjuk/exception/ErrorCode.java
@@ -47,6 +47,8 @@ public enum ErrorCode {
     // =========================
     POST_NOT_FOUND("POST_NOT_FOUND", "게시글을 찾을 수 없습니다.", 404),
     NOT_POST_AUTHOR("NOT_POST_AUTHOR", "게시글 작성자만 수정 또는 삭제할 수 있습니다.", 403),
+    POST_ACCESS_DENIED("POST_ACCESS_DENIED", "게시글 작성 권한이 없습니다.", 403),
+    POST_MODIFY_ACCESS_DENIED("POST_MODIFY_ACCESS_DENIED", "게시글 수정/삭제 권한이 없습니다.", 403),
     FILE_SIZE_EXCEEDED("FILE_SIZE_EXCEEDED", "파일 크기가 제한을 초과했습니다.", 400),
 
     // =========================
@@ -54,6 +56,14 @@ public enum ErrorCode {
     // =========================
     COMMENT_NOT_FOUND("COMMENT_NOT_FOUND", "댓글을 찾을 수 없습니다.", 404),
     NOT_COMMENT_AUTHOR("NOT_COMMENT_AUTHOR", "댓글 작성자만 수정 또는 삭제할 수 있습니다.", 403),
+    COMMENT_ACCESS_DENIED("COMMENT_ACCESS_DENIED", "댓글 작성 권한이 없습니다.", 403),
+    COMMENT_MODIFY_ACCESS_DENIED("COMMENT_MODIFY_ACCESS_DENIED", "댓글 수정/삭제 권한이 없습니다.", 403),
+
+    // =========================
+    // 🎯 게시판 규칙 관련
+    // =========================
+    BOARD_ACCESS_DENIED("BOARD_ACCESS_DENIED", "게시판 접근 권한이 없습니다. HOST 또는 승인된 참여자만 이용할 수 있습니다.", 403),
+    MEETING_BOARD_MISMATCH("MEETING_BOARD_MISMATCH", "해당 모임의 게시글이 아닙니다.", 400),
 
     // =========================
     // ❤️ 좋아요 / 후기 관련

--- a/src/main/java/com/bookjuk/repository/board/CommentRepository.java
+++ b/src/main/java/com/bookjuk/repository/board/CommentRepository.java
@@ -4,8 +4,136 @@ import com.bookjuk.domain.board.Comment;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
+
+/**
+ * 댓글 엔터티에 대한 데이터 접근을 담당하는 Repository 인터페이스
+ *
+ * 특정 게시글의 댓글 목록 조회(페이징, 정렬)
+ * 댓글 작성자 권한 확인
+ * 게시글별 댓글 개수 조회
+ * 댓글 일괄 삭제 (게시글 삭제 시)
+ * 기본적인 CRUD
+ */
+@Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+
+
+    /**
+     * 특정 게시글의 댓글 목록을 작성 시간 순으로 조회한다. (페이징 처리 오래된 댓글우선)
+     * 게시글 상세 조회 시 댓글 목록을 표시하기 위해 사용된다
+     *
+     * @param postId 게시글 ID
+     * @param pageable 페이징 정보 (페이지 번호, 크기, 정렬)
+     * @return 댓글 페이지 객체
+     */
     Page<Comment> findByPostIdOrderByCreatedAtAsc(Long postId, Pageable pageable);
+
+    /**
+     * 특정 댓글의 작성자인지 확인한다. (수정,삭제 권한 확인 시)
+     *
+     * @param id 댓글 ID
+     * @param userId 사용자 ID
+     * @return 작성자이면 true, 아니면 false
+     */
     boolean existsByIdAndUserId(Long id, Long userId);
+
+    /**
+     * 특정 게시글의 댓글 개수를 조회한다.
+     *
+     * @param postId 게시글 ID
+     * @return 댓글 개수
+     */
+    long countByPostId(Long postId);
+
+    /**
+     * 특정 사용자가 작성한 댓글 목록을 조회합니다. (역순 정렬)
+     *
+     * @param userId 사용자 ID
+     * @param pageable 페이징 정보
+     * @return 댓글 페이지 객체
+     */
+    Page<Comment> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    /**
+     * 특정 게시글의 댓글을 모두 삭제한다. (게시글 삭제 시 모든 댓글 삭제)
+     * FK 제약이 없으므로 수동으로 처리
+     *
+     * @param postId 게시글 ID
+     * @return 삭제된 댓글 개수
+     */
+    @Modifying
+    @Query("DELETE FROM Comment c WHERE c.postId = :postId")
+    int deleteByPostId(@Param("postId") Long postId);
+
+    /**
+     * 특정 게시글의 댓글 목록을 List로 조회한다.(페이징 없이)
+     * 작성 시간 순으로 정렬된다.
+     *
+     * @param postId 게시글 ID
+     * @return 댓글 리스트
+     */
+    List<Comment> findByPostIdOrderByCreatedAtAsc(Long postId);
+
+    /**
+     * 특정 게시글의 최신 댓글을 조회한다. (최신 댓글 미리보기)
+     *
+     * @param postId 게시글 ID
+     * @return 최신 댓글 Optional 객체 (존재하지 않으면 empty)
+     */
+    @Query("SELECT c FROM Comment c WHERE c.postId = :postId ORDER BY c.createdAt DESC LIMIT 1")
+    Optional<Comment> findTopByPostIdOrderByCreatedAtDesc(@Param("postId") Long postId);
+
+    /**
+     * 특정 게시글의 첫 번째 댓글을 조회합니다. (첫 댓글 표시)
+     *
+     * @param postId 게시글 ID
+     * @return 첫 번째 댓글 Optional 객체 (존재하지 않으면 empty)
+     */
+    @Query("SELECT c FROM Comment c WHERE c.postId = :postId ORDER BY c.createdAt ASC LIMIT 1")
+    Optional<Comment> findTopByPostIdOrderByCreatedAtAsc(@Param("postId") Long postId);
+
+    /**
+     * 여러 게시글의 댓글 개수를 한 번에 조회. (효율 up)
+     * N+1 문제를 방지
+     *
+     * @param postIds 게시글 ID 목록
+     * @return 게시글 ID를 키로 하고 댓글 개수를 값으로 하는 결과 리스트
+     */
+    @Query("SELECT c.postId, COUNT(c) FROM Comment c WHERE c.postId IN :postIds GROUP BY c.postId")
+    List<Object> countByPostIdIn(@Param("postIds") List<Long> postIds);
+
+    /**
+     * 특정 사용자가 특정 게시글에 작성한 댓글 개수를 조회한다.
+     * 중복 댓글 방지나 사용자별 활동 제한 시 사용
+     *
+     * @param postId 게시글 ID
+     * @param userId 사용자 ID
+     * @return 댓글 개수
+     */
+    long countByPostIdAndUserId(Long postId, Long userId);
+
+    /**
+     * 특정 모임의 모든 게시글에서 특정 사용자가 작성한 댓글을 조회한다.
+     *
+     * @param meetingId 모임 ID
+     * @param userId 사용자 ID
+     * @param pageable 페이징 정보
+     * @return 댓글 페이지 객체
+     */
+    @Query("SELECT c FROM Comment c JOIN Post p ON c.postId = p.postId " +
+            "WHERE p.meetingId = :meetingId AND c.userId = :userId " +
+            "ORDER BY c.createdAt DESC")
+    Page<Comment> findByMeetingIdAndUserIdOrderByCreatedAtDesc(
+            @Param("meetingId") Long meetingId,
+            @Param("userId") Long userId,
+            Pageable pageable);
+
 }

--- a/src/main/java/com/bookjuk/repository/board/PostRepository.java
+++ b/src/main/java/com/bookjuk/repository/board/PostRepository.java
@@ -4,11 +4,107 @@ import com.bookjuk.domain.board.Post;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+
+/**
+ * 게시글 엔터티에 대한 데이터 접근을 담당하는 Repository 인터페이스
+ *
+ * 특정 모임의 게시글 목록 조회(페이징, 정렬)
+ * 모임 ID와 게시글 ID로 게시글 상세 조회
+ * 게시글 작성자 권한 확인
+ * 기본적인 CRUD 작업
+ */
+@Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
+
+    /**
+     * 특정 모임의 게시글 목록을 작성 시간 역순으로 조회한다.
+     * @param meetingId 모임 ID
+     * @param pageable 페이징 정보 (페이지 번호, 크기, 정렬)
+     * @return 게시글 페이지 객체
+     */
     Page<Post> findByMeetingIdOrderByCreatedAtDesc(Long meetingId, Pageable pageable);
+
+    /**
+     * 특정 모임의 특정 게시글을 조회한다.
+     * 게시글 ID와 모임 ID가 모두 일치하는 게시글만 조회된다.(다른 모임 방지)
+     *
+     * @param postId 게시글 Id
+     * @param meetingId 모임 ID
+     * @return 게시글 Optional 객체 (존재하지 않으면 empty)
+     */
     Optional<Post> findByPostIdAndMeetingId(Long postId, Long meetingId);
+
+    /**
+     * 특정 게시글의 작성자인지 확인한다 (수정,삭제 권한 시)
+     *
+     * @param postId 게시글 ID
+     * @param userId 사용자 ID
+     * @return 작성자이면 true 아니면 false
+     */
     boolean existsByPostIdAndUserId(Long postId, Long userId);
+
+    /**
+     * 특정 모임의 게시글 목록을 조회한다.
+     *
+     * @param meetingId 모임 ID
+     * @return 개시글 개수
+     */
+    long countByMeetingId(Long meetingId);
+
+    /**
+     * 특정 사용자가 작성한 게시글 목록을 조회한다. (역순 정렬)
+     *
+     * @param userId 사용자 ID
+     * @param pageable 페이징 정보
+     * @return 게시글 페이지 객체
+     */
+    Page<Post> findByUserIdOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    /**
+     * 특정 모임에서 특정 사용자가 작성한 게시글 개수를 조회한다.
+     *
+     * @param meetingId 모임 ID
+     * @param userId 사용자 ID
+     * @return 게시글 개수
+     */
+    long countByMeetingIdAndUserId(Long meetingId, Long userId);
+
+    /**
+     * 특정 모임의 게시글 중 제목에 특정 키워드가 포함된 게시글을 검색한다.
+     * 대소문자를 구분하지 않고 역순으로 정렬
+     *
+     * @param meetingId 모임 ID
+     * @param keyword 검색 키워드
+     * @param pageable 페이징 정보
+     * @return 검색된 게시글 페이지 객체
+     */
+    @Query("SELECT p FROM Post p WHERE p.meetingId = :meetingId AND LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) ORDER BY p.createdAt DESC")
+    Page<Post> findByMeetingIdAndTitleContainingIgnoreCase(
+            @Param("meetingId") Long meetingId,
+            @Param("keyword") String keyword,
+            Pageable pageable);
+
+    /**
+     * 특정 모임의 게시글 중 제목 또는 내용에 특정 키워드가 포함된 게시글을 검색한다.
+     * 대소문자를 구분하지 않고 역순으로 정렬.
+     *
+     * @param meetingId 모임 ID
+     * @param keyword 검색 키워드
+     * @param pageable 페이징 정보
+     * @return 검색된 게시글 페이지 객체
+     */
+    @Query("SELECT p FROM Post p WHERE p.meetingId = :meetingId AND " +
+            "(LOWER(p.title) LIKE LOWER(CONCAT('%', :keyword, '%')) OR " +
+            "LOWER(p.content) LIKE LOWER(CONCAT('%', :keyword, '%'))) " +
+            "ORDER BY p.createdAt DESC")
+    Page<Post> findByMeetingIdAndTitleOrContentContainingIgnoreCase(
+            @Param("meetingId") Long meetingId,
+            @Param("keyword") String keyword,
+            Pageable pageable);
 }

--- a/src/main/java/com/bookjuk/service/BoardService.java
+++ b/src/main/java/com/bookjuk/service/BoardService.java
@@ -1,0 +1,375 @@
+package com.bookjuk.service;
+
+import com.bookjuk.domain.board.Comment;
+import com.bookjuk.domain.board.Post;
+import com.bookjuk.domain.user.User;
+import com.bookjuk.dto.board.request.CommentCreateRequest;
+import com.bookjuk.dto.board.request.CommentUpdateRequest;
+import com.bookjuk.dto.board.request.PostCreateRequest;
+import com.bookjuk.dto.board.request.PostUpdateRequest;
+import com.bookjuk.dto.board.response.CommentResponse;
+import com.bookjuk.dto.board.response.PostDetailResponse;
+import com.bookjuk.dto.board.response.PostListResponse;
+import com.bookjuk.exception.CustomException;
+import com.bookjuk.exception.ErrorCode;
+import com.bookjuk.repository.board.CommentRepository;
+import com.bookjuk.repository.board.PostRepository;
+import com.bookjuk.repository.participant.MeetingParticipantRepository;
+import com.bookjuk.repository.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+
+/**
+ * 모임 게시판 관련 비즈니스 로직을 처리하는 서비스 클래스.
+ * 목록 조회(페이징, 작석자 닉네임 포함)
+ * 상세 조회 (댓글 및 작성자 정보 포함)
+ * 게시글 작성, 수정, 삭제
+ * 댓글 작성, 수정, 삭제
+ * 게시글,댓글 접근 권한 검증
+ *
+ * 게시글,댓글 작성: HOST 또는 APPROVED 상태의 PARTICIPANT만 가능
+ * 게시글, 댓글 수정/삭제: 작성자 또는 HOST만 가능
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BoardService {
+
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final MeetingParticipantRepository participantRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 특정 모임의 게시글 목록을 페이징하여 조회한다.
+     * N+1 문제를 방지하기 위해 게시글 작성자들의 닉네임을 한번에 조회
+     *
+     * @param meetingId 모임Id
+     * @param page 페이지 번호(1부터시작)
+     * @param size 페이지 크기
+     * @return 게시글 목록 (작성자 닉네임 포함)
+     * @throws CustomException 잘못된 페이지 파라미터인 경우 (INVALID_INPUT)
+     */
+    @Transactional(readOnly = true)
+    public Page<PostListResponse> getPostList(Long meetingId, int page, int size) {
+        // 페이지 파라미터 유효성 검증
+        if (page < 1 || size < 1) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+
+        Pageable pageable = PageRequest.of(page - 1, size);
+        Page<Post> posts = postRepository.findByMeetingIdOrderByCreatedAtDesc(meetingId, pageable);
+
+        // 게시글 작성자들의 ID 목록 수집
+        List<Long> userIds = posts.getContent().stream()
+                .map(Post::getUserId)
+                .distinct()
+                .collect(Collectors.toList());
+
+        // 사용자 정보 한번에 조회 (N+1 문제 해결)
+        Map<Long, String> userNameMap = userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, User::getUsername));
+
+        return posts.map(post -> PostListResponse.from(post, userNameMap.get(post.getUserId())));
+    }
+
+    /**
+     * 특정 게시글의 상세 정보를 조회한다. (
+     * 게시글과 함께 첫번째 댓글(있을때)도 함께 조회하며 게시글 작성자와 댓글 작성자의 닉네임도 포함된다.
+     *
+     * @param meetingId 모임 ID
+     * @param  postId 게시글 ID
+     * @return 게시글 상세 정보 (댓글 및 작성자 정보 포함)
+     * @throws CustomException 게시글을 찾을 수 없는 경우 (POST_NOT_FOUND)
+     */
+    @Transactional(readOnly = true)
+    public PostDetailResponse getPostDetail(Long meetingId, Long postId) {
+        Post post = postRepository.findByPostIdAndMeetingId(postId, meetingId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        // 댓글 목록 조회 (페이징 없이 모든 댓글 조회)
+        Page<Comment> comments = commentRepository.findByPostIdOrderByCreatedAtAsc(postId, Pageable.unpaged());
+
+        // 게시글 작성자와 댓글 작성자들의 ID 수집
+        List<Long> allUserIds = comments.getContent().stream()
+                .map(Comment::getUserId)
+                .collect(Collectors.toList());
+        allUserIds.add(post.getUserId());
+
+        // 사용자 정보 한 번에 조회
+        Map<Long, String> userUsernameMap = userRepository.findAllById(allUserIds).stream()
+                .collect(Collectors.toMap(User::getId, User::getUsername));
+
+        // 게시글 작성자 username 조회
+        String postAuthorUsername = userUsernameMap.getOrDefault(post.getUserId(), "알 수 없는 사용자");
+
+        // 댓글 응답 DTO 생성
+        List<CommentResponse> commentResponses = comments.getContent().stream()
+                .map(comment -> CommentResponse.from(comment, userUsernameMap.getOrDefault(comment.getUserId(), "알 수 없는 사용자")))
+                .collect(Collectors.toList());
+
+        return PostDetailResponse.from(post, postAuthorUsername, commentResponses);
+    }
+
+    /**
+     * 새로운 게시글을 작성한다 (권한 확인 후 게시글 생성)
+     * HOST 또는 APPROVED 상태의 PARTICIPANT만 작성할 수 있다.
+     *
+     * @param meetingId 모임 ID
+     * @param userId 작성자 ID
+     * @param request 게시글 작성 요청 데이터
+     * @return 생성된 게시글 ID
+     * @throws CustomException 작성 권한이 없는 경우 (POST_ACCESS_DENIED)
+     * @throws CustomException 입력 데이터가 유효하지 않은 경우 (INVALID_INPUT)
+     */
+    public Long createPost(Long meetingId, Long userId, PostCreateRequest request) {
+        // 입력 데이터 유효성 검증
+        validatePostRequest(request.getTitle(), request.getContent());
+
+        // 권한 확인: HOST 또는 APPROVED 상태의 PARTICIPANT만 가능
+        if (!participantRepository.existsMemberWithAccess(meetingId, userId)) {
+            throw new CustomException(ErrorCode.POST_ACCESS_DENIED);
+        }
+
+        Post post = Post.builder()
+                .meetingId(meetingId)
+                .userId(userId)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .imageUrl(request.getImageUrl())
+                .build();
+
+        Post savedPost = postRepository.save(post);
+        return savedPost.getPostId();
+    }
+
+    /**
+     * 기존 게시글을 수정한다.(작성자 또는 HOST 확인 후 수정)
+     *
+     * @param meetingId 모임 ID
+     * @param postId 게시글 ID
+     * @param userId 수정 요청자 ID
+     * @param request 게시글 수정 데이터
+     * @throws CustomException 게시글을 찾을 수 없는 경우 (POST_NOT_FOUND)
+     * @throws CustomException 수정 권한이 없는 경우 (POST_MODIFY_ACCESS_DENIED)
+     * @throws CustomException 입력 데이터가 유효하지 않은 경우 (INVALID_INPUT)
+     */
+    public void updatePost(Long meetingId, Long postId, Long userId, PostUpdateRequest request) {
+        // 입력 데이터 유효성 검증
+        validatePostRequest(request.getTitle(), request.getContent());
+
+        Post post = postRepository.findByPostIdAndMeetingId(postId, meetingId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        // 권한 확인: 작성자 또는 호스트만 수정 가능
+        if (!canModifyPost(meetingId, postId, userId)) {
+            throw new CustomException(ErrorCode.POST_MODIFY_ACCESS_DENIED);
+        }
+
+        post.edit(request.getTitle(), request.getContent(), request.getImageUrl());
+    }
+
+    /**
+     * 게시글을 삭제한다.(작성자 또는 HOST 확인 후 관련 게시글과 댓글을 모두 삭제)
+     * FK 제약이 없으므로 댓글을 먼저 수동으로 삭제한다.
+     *
+     * @param meetingId 모임 ID
+     * @param postId 게시글 ID
+     * @param userId 삭제 요청자 ID
+     * @throws CustomException 게시글을 찾을 수 없는 경우 (POST_NOT_FOUND)
+     * @throws CustomException 삭제 권한이 없는 경우 (POST_MODIFY_ACCESS_DENIED)
+     */
+    public void deletePost(Long meetingId, Long postId, Long userId) {
+        Post post = postRepository.findByPostIdAndMeetingId(postId, meetingId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        // 권한 확인: 작성자 또는 호스트만 삭제 가능
+        if (!canModifyPost(meetingId, postId, userId)) {
+            throw new CustomException(ErrorCode.POST_MODIFY_ACCESS_DENIED);
+        }
+
+        // 댓글 먼저 삭제 (FK 제약이 없으므로 수동으로 처리)
+        commentRepository.findByPostIdOrderByCreatedAtAsc(postId, Pageable.unpaged())
+                .getContent()
+                .forEach(comment -> commentRepository.delete(comment));
+
+        postRepository.delete(post);
+    }
+
+    /**
+     * 게시글에 댓글을 작성한다.(한개 제한에서 여러개의 댓글로 변경)
+     * HOST 또는 APPROVED 상태의 PARTICIPANT만 작성할 수 있다.
+     *
+     * @param meetingId 모임 ID
+     * @param postId 게시글 ID
+     * @param userId 작성자 ID
+     * @param request 댓글 작성 요청 데이터
+     * @return 생성된 댓글 ID
+     * @throws CustomException 게시글을 찾을 수 없는 경우 (POST_NOT_FOUND)
+     * @throws CustomException 작성 권한이 없는 경우 (COMMENT_ACCESS_DENIED)
+     * @throws CustomException 입력 데이터가 유효하지 않은 경우 (INVALID_INPUT)
+     */
+    public Long createComment(Long meetingId, Long postId, Long userId, CommentCreateRequest request) {
+        // 입력 데이터 유효성 검증
+        validateCommentRequest(request.getContent());
+
+        // 게시글 존재 확인
+        Post post = postRepository.findByPostIdAndMeetingId(postId, meetingId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        // 권한 확인: HOST 또는 APPROVED 상태의 PARTICIPANT만 가능
+        if (!participantRepository.existsMemberWithAccess(meetingId, userId)) {
+            throw new CustomException(ErrorCode.COMMENT_ACCESS_DENIED);
+        }
+
+        Comment comment = Comment.builder()
+                .postId(postId)
+                .userId(userId)
+                .content(request.getContent())
+                .build();
+
+        Comment savedComment = commentRepository.save(comment);
+        return savedComment.getId();
+    }
+
+    /**
+     * 댓글을 수정합니다.
+     *
+     * <p>수정 권한(작성자 또는 HOST)을 확인한 후 댓글 내용을 수정합니다.
+     *
+     * @param meetingId 모임 ID
+     * @param postId 게시글 ID
+     * @param commentId 댓글 ID
+     * @param userId 수정 요청자 ID
+     * @param request 댓글 수정 데이터
+     * @throws CustomException 게시글을 찾을 수 없는 경우 (POST_NOT_FOUND)
+     * @throws CustomException 댓글을 찾을 수 없는 경우 (COMMENT_NOT_FOUND)
+     * @throws CustomException 수정 권한이 없는 경우 (COMMENT_MODIFY_ACCESS_DENIED)
+     * @throws CustomException 입력 데이터가 유효하지 않은 경우 (INVALID_INPUT)
+     */
+    public void updateComment(Long meetingId, Long postId, Long commentId, Long userId, CommentUpdateRequest request) {
+        // 입력 데이터 유효성 검증
+        validateCommentRequest(request.getContent());
+
+        // 게시글 존재 확인
+        postRepository.findByPostIdAndMeetingId(postId, meetingId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        // 권한 확인: 작성자 또는 호스트만 수정 가능
+        if (!canModifyComment(meetingId, commentId, userId)) {
+            throw new CustomException(ErrorCode.COMMENT_MODIFY_ACCESS_DENIED);
+        }
+
+        comment.edit(request.getContent());
+    }
+
+    /**
+     * 댓글을 삭제합니다 (작성자 또는 HOST 확인 후 댓글 삭제)
+     *
+     * @param meetingId 모임 ID
+     * @param postId 게시글 ID
+     * @param commentId 댓글 ID
+     * @param userId 삭제 요청자 ID
+     * @throws CustomException 게시글을 찾을 수 없는 경우 (POST_NOT_FOUND)
+     * @throws CustomException 댓글을 찾을 수 없는 경우 (COMMENT_NOT_FOUND)
+     * @throws CustomException 삭제 권한이 없는 경우 (COMMENT_MODIFY_ACCESS_DENIED)
+     */
+    public void deleteComment(Long meetingId, Long postId, Long commentId, Long userId) {
+        // 게시글 존재 확인
+        postRepository.findByPostIdAndMeetingId(postId, meetingId)
+                .orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new CustomException(ErrorCode.COMMENT_NOT_FOUND));
+
+        // 권한 확인: 작성자 또는 호스트만 삭제 가능
+        if (!canModifyComment(meetingId, commentId, userId)) {
+            throw new CustomException(ErrorCode.COMMENT_MODIFY_ACCESS_DENIED);
+        }
+
+        commentRepository.delete(comment);
+    }
+
+    /**
+     * 게시글 수정/삭제 권한을 확인한다.(작성자, 해당모임의 HOST인 경우)
+     *
+     * @param meetingId 모임 ID
+     * @param postId 게시글 ID
+     * @param userId 사용자 ID
+     * @return 권한이 있으면 true, 없으면 false
+     */
+    private boolean canModifyPost(Long meetingId, Long postId, Long userId) {
+        // 작성자인지 확인
+        boolean isAuthor = postRepository.existsByPostIdAndUserId(postId, userId);
+        if (isAuthor) {
+            return true;
+        }
+
+        // 호스트인지 확인
+        return participantRepository.existsByMeeting_IdAndParticipant_IdAndRole(
+                meetingId, userId, com.bookjuk.domain.participant.ParticipantRole.HOST);
+    }
+
+    /**
+     * 댓글 수정/삭제 권한을 확인한다. (작성자, 해당모임의 HOST인 경우)
+     *
+     * @param meetingId 모임 ID
+     * @param commentId 댓글 ID
+     * @param userId 사용자 ID
+     * @return 권한이 있으면 true, 없으면 false
+     */
+    private boolean canModifyComment(Long meetingId, Long commentId, Long userId) {
+        // 작성자인지 확인
+        boolean isAuthor = commentRepository.existsByIdAndUserId(commentId, userId);
+        if (isAuthor) {
+            return true;
+        }
+
+        // 호스트인지 확인
+        return participantRepository.existsByMeeting_IdAndParticipant_IdAndRole(
+                meetingId, userId, com.bookjuk.domain.participant.ParticipantRole.HOST);
+    }
+
+    /**
+     * 게시글 요청 데이터의 유효성을 검증한다.
+     *
+     * @param title 게시글 제목
+     * @param content 게시글 내용
+     * @throws CustomException 제목이나 내용이 비어있는 경우 (INVALID_INPUT)
+     */
+    private void validatePostRequest(String title, String content) {
+        if (title == null || title.trim().isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+        if (content == null || content.trim().isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+        if (title.length() > 200) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+    }
+
+    /**
+     * 댓글 요청 데이터의 유효성을 검증한다.
+     *
+     * @param content 댓글 내용
+     * @throws CustomException 내용이 비어있는 경우 (INVALID_INPUT)
+     */
+    private void validateCommentRequest(String content) {
+        if (content == null || content.trim().isEmpty()) {
+            throw new CustomException(ErrorCode.INVALID_INPUT);
+        }
+    }
+}


### PR DESCRIPTION
### 설명
 - 게시판 파일들 작성 (파일별 커밋 완료), 코드 전부 주석과 javadoc 추가 완료
 
### 주요 변경사항
 - 핵심 비즈니스 로직 (권한관리)
   - 게시글/댓글 작성: HOST 또는 APPROVED 상태의 PARTICIPANT만 가능
   - 게시글/댓글 수정/삭제: 작성자 또는 HOST만 가능
 - 하나만 작성 가능했던 댓글 제한 제거
 - FK 제약이 없으므로 삭제 시 댓글도 수동으로 삭제
 - 현재 임시 파라미터로 구현중인 @RequestAttribute("userid") 부분은 JWT 인터셉터에서 설정되어야 함
 - 필수 아닌 예정이었던 언제든 작업할 수 있게 추가로 조회 기능 추가 완료 (게시판 분리 가능성 포함)
   
### 테스트 여부(수동/자동)

  
### 관련 이슈 번호
#52 #53 #54 #56 
