### PR TITLE
feat: 마이페이지 비즈니스 로직 구현

### DIFF
--- a/src/main/java/com/bookjuk/dto/mypage/MyPageResponse.java
+++ b/src/main/java/com/bookjuk/dto/mypage/MyPageResponse.java
@@ -32,12 +32,12 @@ public class MyPageResponse {
 
 
     // 마이페이지 응답 dto로 바꾸는 정적 팩토리 메소드
-    public static MyPageResponse of(UserInfoDto profile, StaticsInfoDto statistics, List<MeetingInfoDto> meeting) {
+    public static MyPageResponse of(UserInfoDto profile, StaticsInfoDto statistics, List<MeetingInfoDto> meetings) {
 
         return MyPageResponse.builder()
                 .profile(profile)
                 .statistics(statistics)
-                .meetings(meeting)
+                .meetings(meetings)
                 .build();
     }
 }

--- a/src/main/java/com/bookjuk/dto/mypage/StaticsInfoDto.java
+++ b/src/main/java/com/bookjuk/dto/mypage/StaticsInfoDto.java
@@ -17,10 +17,10 @@ import lombok.NoArgsConstructor;
 @Builder
 public class StaticsInfoDto {
 
-    private int receivedLikes;
+    private Long receivedLikes;
     private int participatedMeeting;
 
-    public static StaticsInfoDto of(int likes, int meetings) {
+    public static StaticsInfoDto of(Long likes, int meetings) {
         return StaticsInfoDto.builder()
                 .receivedLikes(likes)
                 .participatedMeeting(meetings)

--- a/src/main/java/com/bookjuk/dto/review/ReviewResponse.java
+++ b/src/main/java/com/bookjuk/dto/review/ReviewResponse.java
@@ -21,11 +21,8 @@ public class ReviewResponse {
     public static ReviewResponse from(MeetingReview review) {
         ReviewResponse response = ReviewResponse.builder()
                 .reviewId(review.getId())
-                // 유저 엔터티 생성 후 주석 제거
-                /*
                 .fromUserId(review.getReviewer().getId())
                 .toUserId(review.getReviewee().getId())
-                */
                 .createdAt(review.getCreatedAt())
                 .build();
 

--- a/src/main/java/com/bookjuk/repository/participant/MeetingParticipantCustom.java
+++ b/src/main/java/com/bookjuk/repository/participant/MeetingParticipantCustom.java
@@ -1,5 +1,6 @@
 package com.bookjuk.repository.participant;
 
+import com.bookjuk.domain.participant.MeetingParticipant;
 import com.bookjuk.domain.user.User;
 
 import java.util.List;
@@ -8,5 +9,8 @@ public interface MeetingParticipantCustom {
 
     // 미팅 id로 미팅 참여자 찾기
     List<User> findMeetingParticipantsByMeetingId(Long id);
+
+    // 유저 id로 참여 미팅 리스트 반환
+    List<MeetingParticipant> findMeetingsByUserId(Long id);
 
 }

--- a/src/main/java/com/bookjuk/repository/participant/MeetingParticipantRepositoryImpl.java
+++ b/src/main/java/com/bookjuk/repository/participant/MeetingParticipantRepositoryImpl.java
@@ -1,5 +1,6 @@
 package com.bookjuk.repository.participant;
 
+import com.bookjuk.domain.participant.MeetingParticipant;
 import com.bookjuk.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -12,7 +13,7 @@ import static com.bookjuk.domain.participant.QMeetingParticipant.meetingParticip
 @RequiredArgsConstructor
 public class MeetingParticipantRepositoryImpl implements MeetingParticipantCustom {
 
-    // queryDsl을 사용하기 위한 의존객체
+    // queryDsl 을 사용하기 위한 의존객체
     private final JPAQueryFactory factory;
 
     // 미팅 id로 참여자 찾기
@@ -22,6 +23,15 @@ public class MeetingParticipantRepositoryImpl implements MeetingParticipantCusto
                 .select(meetingParticipant.participant)
                 .from(meetingParticipant)
                 .where(meetingParticipant.meeting.id.eq(id))
+                .fetch();
+    }
+
+    // 유저 id로 참여한 미팅 id 반환
+    @Override
+    public List<MeetingParticipant> findMeetingsByUserId(Long id) {
+        return factory
+                .selectFrom(meetingParticipant)
+                .where(meetingParticipant.participant.id.eq(id))
                 .fetch();
     }
 

--- a/src/main/java/com/bookjuk/repository/review/MeetingReviewCustom.java
+++ b/src/main/java/com/bookjuk/repository/review/MeetingReviewCustom.java
@@ -7,4 +7,7 @@ public interface MeetingReviewCustom {
 
     // 한 미팅에서 좋아요가 중복인지 체크
     boolean existDuplicateReview(Meeting meeting, User reviewer, User reviewee);
+
+    // 유저 id 별로 좋아요 받은 개수 확인
+    Long countReviewByUserId(Long id);
 }

--- a/src/main/java/com/bookjuk/repository/review/MeetingReviewRepositoryImpl.java
+++ b/src/main/java/com/bookjuk/repository/review/MeetingReviewRepositoryImpl.java
@@ -24,4 +24,14 @@ public class MeetingReviewRepositoryImpl implements MeetingReviewCustom {
                 .fetchOne() != null ? true : false;
 
     }
+
+    @Override
+    public Long countReviewByUserId(Long id) {
+        return factory
+                .select(meetingReview.reviewee.count())
+                .from(meetingReview)
+                .where(meetingReview.reviewee.id.eq(id))
+                .fetchOne()
+                ;
+    }
 }

--- a/src/main/java/com/bookjuk/service/MyPageService.java
+++ b/src/main/java/com/bookjuk/service/MyPageService.java
@@ -1,5 +1,8 @@
 package com.bookjuk.service;
 
+import com.bookjuk.domain.user.User;
+import com.bookjuk.dto.mypage.UserInfoDto;
+import com.bookjuk.exception.CustomException;
 import com.bookjuk.repository.meeting.MeetingRepository;
 import com.bookjuk.repository.participant.MeetingParticipantRepository;
 import com.bookjuk.repository.review.MeetingReviewRepository;
@@ -19,8 +22,32 @@ public class MyPageService {
 
     /**
      * 마이페이지 진입 정보 조회(디폴트) 로직입니다.
+     * @param //username - 로그인한 유저가 제시한 토큰에서 파싱한 이름
+     * 일단 테스트 하기 위해 받는 파라미터는 id로 설정 추후 username 파싱 완료
+     * 사용자 정보조회 구현이 완료되면 username 으로 변경할 예정
      */
-    public void viewMyPage(Long userId) {
+    public void viewMyPage(String username) {
+
+        // 1. 유저네임으로 유저 정보 가져오기
+        User user = userRepository.findByUsername(username).orElseThrow(
+                () -> new CustomException()
+        );
+
+        // 2. 조회된 유저 정보를 마이페이지 응답에 필요한 dto로 변경
+        UserInfoDto userInfoDto = UserInfoDto.from(user);
+
+        // 3. 유저가 참여한 미팅 정보 가져오기
+        // meeting_participant 에 유저 id로 참여 미팅 id를 리스트로 반환
+        Long userId = user.getId();
+        meetingParticipantRepository.findMeetingsByUserId(userId);
+
+        // 반환된 리스트를 for 돌려서 dto로 매핑
+        // 매핑된 dto를 다시 리스트로 합치기
+
+        // 4. 유저의 모임 참여, 좋아요 통계 정보를 가져오기
+
+
+
 
     }
 }

--- a/src/main/java/com/bookjuk/service/MyPageService.java
+++ b/src/main/java/com/bookjuk/service/MyPageService.java
@@ -1,17 +1,28 @@
 package com.bookjuk.service;
 
+import com.bookjuk.domain.participant.MeetingParticipant;
 import com.bookjuk.domain.user.User;
+import com.bookjuk.dto.mypage.MeetingInfoDto;
+import com.bookjuk.dto.mypage.MyPageResponse;
+import com.bookjuk.dto.mypage.StaticsInfoDto;
 import com.bookjuk.dto.mypage.UserInfoDto;
 import com.bookjuk.exception.CustomException;
+import com.bookjuk.exception.ErrorCode;
 import com.bookjuk.repository.meeting.MeetingRepository;
 import com.bookjuk.repository.participant.MeetingParticipantRepository;
 import com.bookjuk.repository.review.MeetingReviewRepository;
 import com.bookjuk.repository.user.UserRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 @RequiredArgsConstructor
 @Service
+@Transactional
 public class MyPageService {
 
     // 의존 객체 주입
@@ -22,32 +33,67 @@ public class MyPageService {
 
     /**
      * 마이페이지 진입 정보 조회(디폴트) 로직입니다.
-     * @param //username - 로그인한 유저가 제시한 토큰에서 파싱한 이름
-     * 일단 테스트 하기 위해 받는 파라미터는 id로 설정 추후 username 파싱 완료
-     * 사용자 정보조회 구현이 완료되면 username 으로 변경할 예정
+     * @param email - 로그인한 유저가 제시한 토큰에서 파싱한 이메일 정보
+     *
      */
-    public void viewMyPage(String username) {
+    public MyPageResponse getMyPage(String email) {
 
-        // 1. 유저네임으로 유저 정보 가져오기
-        User user = userRepository.findByUsername(username).orElseThrow(
-                () -> new CustomException()
-        );
+        // 1. 사용자 이메일로 유저 정보 가져오기
+        User user = getUserByEmail(email);
 
-        // 2. 조회된 유저 정보를 마이페이지 응답에 필요한 dto로 변경
-        UserInfoDto userInfoDto = UserInfoDto.from(user);
+        // 조회된 유저 정보를 마이페이지 응답에 필요한 dto 로 변경
+        UserInfoDto profile = UserInfoDto.from(user);
 
-        // 3. 유저가 참여한 미팅 정보 가져오기
+        // 2. 유저가 참여한 미팅 정보 가져오기
         // meeting_participant 에 유저 id로 참여 미팅 id를 리스트로 반환
         Long userId = user.getId();
-        meetingParticipantRepository.findMeetingsByUserId(userId);
+        List<MeetingInfoDto> meetings = getMeetingsByUserId(userId);
 
-        // 반환된 리스트를 for 돌려서 dto로 매핑
-        // 매핑된 dto를 다시 리스트로 합치기
+        // 3. 유저의 모임 참여, 좋아요 통계 정보를 가져오기
+        int meetingCount = meetings.size();
+        StaticsInfoDto stats = getStatsByUserId(userId, meetingCount);
 
-        // 4. 유저의 모임 참여, 좋아요 통계 정보를 가져오기
+        return MyPageResponse.of(profile, stats, meetings);
 
+    }
 
+    /**
+     * 사용자의 email 정보로 user 객체를 가져올 때 사용하는 메소드입니다.
+     * @param email - 로그인한 유저가 제시한 토큰에서 파싱한 이메일 정보
+     * @return User - 일치하는 사용자 정보가 있으면 해당 User 객체를 반환, 없으면 커스텀 에러를 반환
+     */
+    private User getUserByEmail(String email) {
+        return userRepository.findByEmail(email).orElseThrow(
+                () -> new CustomException(ErrorCode.USER_NOT_FOUND)
+        );
+    }
 
+    /**
+     * 사용자의 id 정보로 참여한 미팅 정보를 가져오고 필요한 정보만 반환하는 메소드입니다.
+     * @param id - 이메일 정보로 찾은 유저의 id
+     * @return - 유저의 id 로 참여한 미팅 정보를 리스트로 받은 후 필요한 정보만 dto 로 매핑한 리스트
+     */
+    private List<MeetingInfoDto> getMeetingsByUserId(Long id) {
+        // 사용자 id 정보로 참여한 미팅 정보 반환
+        List<MeetingParticipant> meetingParticipants =
+                meetingParticipantRepository.findMeetingsByUserId(id);
 
+        // 반환된 리스트를 for 돌려서 dto 로 매핑
+        return meetingParticipants
+                .stream()
+                .map(meeting -> MeetingInfoDto.from(meeting))
+                .collect(Collectors.toList());
+
+    }
+
+    /**
+     * 사용자의 id 정보로 받은 좋아요 개수를 조회하고 참여한 리스트 개수와 함께 필요한 정보만 반환하는 메소드입니다.
+     * @param id - 이메일 정보로 찾은 유저 id
+     * @param count - 참여 리스트의 size
+     * @return - 유저 id 정보롤 찾은 좋아요 개수와 참여 리스트의 개수를 받아 필요한 정보만 매핑한 dto
+     */
+    private StaticsInfoDto getStatsByUserId(Long id, int count) {
+        Long reviewCount = meetingReviewRepository.countReviewByUserId(id);
+        return StaticsInfoDto.of(reviewCount, count);
     }
 }

--- a/src/main/java/com/bookjuk/service/MyPageService.java
+++ b/src/main/java/com/bookjuk/service/MyPageService.java
@@ -17,7 +17,10 @@ public class MyPageService {
     private final MeetingReviewRepository meetingReviewRepository;
     private final MeetingParticipantRepository meetingParticipantRepository;
 
-    public void viewMyPage() {
+    /**
+     * 마이페이지 진입 정보 조회(디폴트) 로직입니다.
+     */
+    public void viewMyPage(Long userId) {
 
     }
 }

--- a/src/main/java/com/bookjuk/service/ReviewService.java
+++ b/src/main/java/com/bookjuk/service/ReviewService.java
@@ -1,4 +1,3 @@
-/*
 package com.bookjuk.service;
 
 import com.bookjuk.domain.meeting.Meeting;
@@ -36,11 +35,10 @@ public class ReviewService {
     private final MeetingParticipantRepository meetingParticipantRepository;
     private final UserRepository userRepository;
 
-    */
 /**
      * 좋아요 남기기 로직
      *
-     *//*
+     */
 
     public ReviewResponse createReview(Long meetingId, Long reviewerId, Long revieweeId) {
 
@@ -105,4 +103,4 @@ public class ReviewService {
 
 
 }
-*/
+


### PR DESCRIPTION
## 개요
- Mypage 기능 구현에 필요한 정보 조회 비즈니스 로직을 작성했습니다.

## 변경 사항
- MyPageService 클래스 생성
- 참여 미팅 정보 조회를 위해 MeetingParticipantCustom, MeetingParticipantRepositoryImpl 에 커스텀 쿼리 메소드 추가
- 받은 좋아요 수 조회를 위해 MeetingReviewCustom, MeetingReviewRepositoryImpl 에 커스텀 쿼리 메소드 추가
- 메소드 별 반환 타입 변경으로 인한 mypage 내 dto 타입 수정

## 테스트 방법
- api controller 구현 후 READ, UPDATE 테스트 예정

## 관련 이슈
- Resolves #67 