### PR TITLE
feat: 로그인 필요 메시지 및 이미지 업로드 제한사항 추가, 모임 생성 시 모임 상세 조회 기능 구현

### DIFF
--- a/src/main/java/com/bookjuk/config/SecurityConfig.java
+++ b/src/main/java/com/bookjuk/config/SecurityConfig.java
@@ -62,11 +62,12 @@ public class SecurityConfig {
 
                                 // 인증 및 권한이 필요한 경로
 //                                .requestMatchers("/api/premium/**").hasAnyAuthority("VIP", "GOLD")
-                                .requestMatchers("/api/**").authenticated()
+//                                .requestMatchers("/api/**").authenticated()
 
                                 // 기타 경로
                                 // 모든 다른 요청은 인증이 필요하다
-                                .anyRequest().authenticated()
+                                // .anyRequest().authenticated() // 원본
+                                .anyRequest().permitAll() // 테스트용
                 )
 
 

--- a/src/main/java/com/bookjuk/controller/MeetingController.java
+++ b/src/main/java/com/bookjuk/controller/MeetingController.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -44,14 +45,16 @@ public class MeetingController {
      * @return 모임 생성 템플릿 또는 로그인 페이지 리다이렉트
      */
     @GetMapping("/meetings/create")
-    public String createMeetingPage(HttpServletRequest request) {
+    public String createMeetingPage(HttpServletRequest request, Model model) {
         log.info("모임 생성 페이지 요청");
 
         // JWT 토큰 검증
         User currentUser = getCurrentUserFromToken(request);
         if (currentUser == null) {
             log.warn("로그인하지 않은 사용자의 모임 생성 페이지 접근 시도");
-            return "redirect:/login"; // 로그인 페이지로 리다이렉트
+            model.addAttribute("loginRequired", true);
+            model.addAttribute("message", "모임을 생성하려면 로그인이 필요합니다.");
+            return "auth"; // 로그인 페이지에 메시지와 함께 이동
         }
 
         log.info("로그인 사용자의 모임 생성 페이지 접근: {}", currentUser.getEmail());
@@ -60,18 +63,27 @@ public class MeetingController {
 
     /**
      * 새로운 모임을 생성합니다.
+     * 
+     * 이미지 업로드 제한사항:
+     * - 선택사항 (없어도 모임 생성 가능)
+     * - 최대 1장만 업로드 가능
+     * - 허용 형식: JPG, JPEG, PNG, GIF, BMP, WEBP
+     * - 최대 크기: 10MB
+     * 
      * @param request 모임 생성 요청 데이터
-     * @param imageFile 모임 대표 이미지 파일 (선택적)
+     * @param imageFile 모임 대표 이미지 파일 (선택적, 최대 1장)
      * @return 생성된 모임의 상세 정보
      */
     @PostMapping("/api/meetings")
     @ResponseBody
     public ResponseEntity<MeetingDetailResponse> createMeeting(
-            @Valid @ModelAttribute MeetingCreateRequest request,
-            @RequestParam(value = "imageFile", required = false) MultipartFile imageFile,
+        // 수업 시간 때 배운 RequestPart를 사용하여 json, Image를 동시에 보내는 api를 생성
+            @Valid @RequestPart("meeting") MeetingCreateRequest request,
+            @RequestPart(value = "imageFile", required = false) MultipartFile imageFile,
             HttpServletRequest httpRequest) {
 
-        log.info("모임 생성 요청 - 제목: {}, 도서: {}", request.getTitle(), request.getBookTitle());
+        log.info("모임 생성 요청 - 제목: {}, 도서: {}, 최대참여자: {}", 
+                 request.getTitle(), request.getBookTitle(), request.getMaxParticipants());
 
         // JWT 토큰에서 현재 사용자 정보 가져오기
         User currentUser = getCurrentUserFromToken(httpRequest);
@@ -88,6 +100,18 @@ public class MeetingController {
 
         log.info("모임 생성 완료 - ID: {}", response.getMeetingId());
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 모임 상세 정보를 조회합니다.
+     * @param id 모임 ID
+     * @return 모임 상세 정보
+     */
+    @GetMapping("/api/meetings/{id}")
+    @ResponseBody
+    public ResponseEntity<MeetingDetailResponse> getMeetingDetail(@PathVariable("id") Long id) {
+        MeetingDetailResponse detail = meetingService.getMeetingDetail(id);
+        return ResponseEntity.ok(detail);
     }
 
     /**

--- a/src/main/java/com/bookjuk/routes/PageController.java
+++ b/src/main/java/com/bookjuk/routes/PageController.java
@@ -3,6 +3,8 @@ package com.bookjuk.routes;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.ui.Model;
 
 /**
  * 페이지 전환 렌더링용 컨트롤러
@@ -39,5 +41,12 @@ public class PageController {
     @GetMapping("/editProfile")
     public String editProfile() {
         return "edit-profile";
+    }
+
+    // 모임 상세 페이지 (Thymeleaf)
+    @GetMapping("/meetings/{id}")
+    public String meetingDetail(@PathVariable("id") Long id, Model model) {
+        model.addAttribute("meetingId", id);
+        return "meeting-detail";
     }
 }

--- a/src/main/resources/templates/auth.html
+++ b/src/main/resources/templates/auth.html
@@ -11,6 +11,12 @@
     <!-- 알림 메시지가 표시될 컨테이너 -->
     <div id="toast-container"></div>
 
+    <!-- 로그인 필요 알림 메시지 -->
+    <div th:if="${loginRequired}" class="alert alert-warning" style="margin: 20px; padding: 15px; background-color: #fff3cd; border: 1px solid #ffeaa7; border-radius: 5px; color: #856404;">
+        <strong>⚠️ 로그인 필요</strong><br>
+        <span th:text="${message}">모임을 생성하려면 로그인이 필요합니다.</span>
+    </div>
+
     <header class="header">
         <h1 class="logo" th:onclick="|window.location.href='@{/}'|">북적북적</h1>
         <a th:href="@{/}" class="back-btn">홈으로</a>

--- a/src/main/resources/templates/create-meeting.html
+++ b/src/main/resources/templates/create-meeting.html
@@ -159,13 +159,14 @@
             <h2 class="section-title">🖼️ 모임 이미지</h2>
 
             <div class="form-group">
-                <label class="form-label">대표 이미지 (선택)</label>
+                <label class="form-label">대표 이미지 (선택사항, 최대 1장)</label>
                 <div class="file-upload-area" onclick="document.getElementById('meetingImage').click()">
                     <div class="upload-icon">📷</div>
                     <div class="upload-text">클릭하여 이미지 업로드</div>
-                    <div class="upload-subtext">JPG, PNG 파일 (최대 10MB)</div>
+                    <div class="upload-subtext">JPG, JPEG, PNG, GIF, BMP, WEBP 파일 (최대 10MB, 1장만 가능)</div>
                 </div>
-                <input type="file" class="file-input" id="meetingImage" name="meetingImage" accept=".jpg,.jpeg,.png" onchange="previewImage(this)">
+                <input type="file" class="file-input" id="meetingImage" name="meetingImage" accept=".jpg,.jpeg,.png,.gif,.bmp,.webp" onchange="previewImage(this)">
+                <div class="helper-text">이미지는 선택사항이며, 업로드하지 않아도 모임을 생성할 수 있습니다.</div>
                 <div class="image-preview" id="imagePreview"></div>
                 <div class="error-message" id="imageError" style="display: none;"></div>
             </div>


### PR DESCRIPTION
## 개요


## 변경 사항
- [Auth] 비로그인 사용자의 모임 생성 페이지 접근 시 `/auth`로 리다이렉트
- [Image] 모임 생성 시 이미지는 한 장만 허용. 두 번째 업로드 시 첫 번째 이미지를 대체
- [Routing] 생성 성공 시 `/meetings/{id}` 상세 페이지로 이동
- [Page] 상세 페이지에서 `/api/meetings/{id}`로 데이터 조회 후 렌더
- [Security] 임시로 공개/또는 인증 필요 등 정책 명시

## 테스트 방법
- 포스트맨으로 회원가입 후 로그인하여 토큰 갖고와서 모임 생성 되는 것을 확인
- __이미지 업로드__: 첫 이미지 업로드 → 두 번째 업로드 시 첫 번째가 제거되고 두 번째로 대체
- __이미지 표시__: 서버에 저장된 이미지 URL이 정상적으로 렌더되는지 확인


## 관련 이슈
- Resolves #76 