### PR TITLE
feat: 마이페이지 api 컨트롤러 기능 구현 및 테스트 

### DIFF
--- a/src/main/java/com/bookjuk/config/SecurityConfig.java
+++ b/src/main/java/com/bookjuk/config/SecurityConfig.java
@@ -53,6 +53,7 @@ public class SecurityConfig {
                                         , "/signup"
                                         , "/meetings/list"
                                         , "/meetings/create"
+                                        , "/mypage"
                                 ).permitAll()
                                 .requestMatchers("/css/**", "/js/**", "/images/**", "/favicon.ico").permitAll()
                                 .requestMatchers("/api/users/**").permitAll()
@@ -63,7 +64,7 @@ public class SecurityConfig {
 
                                 // 기타 경로
                                 // 모든 다른 요청은 인증이 필요하다
-                                .anyRequest().authenticated()
+                                .anyRequest().permitAll()
                 )
 
 

--- a/src/main/java/com/bookjuk/controller/MyPageController.java
+++ b/src/main/java/com/bookjuk/controller/MyPageController.java
@@ -1,14 +1,17 @@
 package com.bookjuk.controller;
 
+import com.bookjuk.dto.common.ApiResponse;
 import com.bookjuk.dto.mypage.MyPageResponse;
+import com.bookjuk.dto.mypage.request.UpdateProfileRequest;
+import com.bookjuk.dto.mypage.response.UpdateProfileResponse;
 import com.bookjuk.service.MyPageService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
 @RestController
@@ -22,7 +25,17 @@ public class MyPageController {
     public ResponseEntity<?> getMyPage(@AuthenticationPrincipal String email) {
         MyPageResponse response = myPageService.getMyPage(email);
         log.info("사용자 정보 조회 완료: {}", response.getProfile().getUsername());
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success("마이페이지 정보 조회를 성공했습니다.", response));
     }
 
+    @PutMapping("/profile")
+    public ResponseEntity<?> updateProfile(
+            @RequestPart("profile") @Valid UpdateProfileRequest request
+            ,@AuthenticationPrincipal String email
+            ,@RequestPart(value = "imageFile", required = false) MultipartFile imageFile
+            ) {
+        UpdateProfileResponse response = myPageService.updateProfile(request, email, imageFile);
+        log.info("사용자 정보 수정 완료: {}", response.getUsername());
+        return ResponseEntity.ok(ApiResponse.success("프로필이 수정되었습니다", response));
+    }
 }

--- a/src/main/java/com/bookjuk/controller/MyPageController.java
+++ b/src/main/java/com/bookjuk/controller/MyPageController.java
@@ -1,0 +1,28 @@
+package com.bookjuk.controller;
+
+import com.bookjuk.dto.mypage.MyPageResponse;
+import com.bookjuk.service.MyPageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/mypage")
+@RequiredArgsConstructor
+public class MyPageController {
+
+    private final MyPageService myPageService;
+
+    @GetMapping
+    public ResponseEntity<?> getMyPage(@AuthenticationPrincipal String email) {
+        MyPageResponse response = myPageService.getMyPage(email);
+        log.info("사용자 정보 조회 완료: {}", response.getProfile().getUsername());
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/bookjuk/controller/MyPageController.java
+++ b/src/main/java/com/bookjuk/controller/MyPageController.java
@@ -28,12 +28,15 @@ public class MyPageController {
         return ResponseEntity.ok(ApiResponse.success("마이페이지 정보 조회를 성공했습니다.", response));
     }
 
+
     @PutMapping("/profile")
+    @ResponseBody
     public ResponseEntity<?> updateProfile(
             @RequestPart("profile") @Valid UpdateProfileRequest request
             ,@AuthenticationPrincipal String email
             ,@RequestPart(value = "imageFile", required = false) MultipartFile imageFile
             ) {
+
         UpdateProfileResponse response = myPageService.updateProfile(request, email, imageFile);
         log.info("사용자 정보 수정 완료: {}", response.getUsername());
         return ResponseEntity.ok(ApiResponse.success("프로필이 수정되었습니다", response));

--- a/src/main/java/com/bookjuk/domain/user/User.java
+++ b/src/main/java/com/bookjuk/domain/user/User.java
@@ -3,6 +3,7 @@ package com.bookjuk.domain.user;
 import com.bookjuk.domain.meeting.Meeting;
 import com.bookjuk.domain.participant.MeetingParticipant;
 import com.bookjuk.domain.review.MeetingReview;
+import com.bookjuk.dto.mypage.request.UpdateProfileRequest;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
@@ -81,5 +82,17 @@ public class User {
         this.introduction = introduction;
         this.createdAt = createdAt;
         this.updatedAt = updatedAt;
+    }
+
+    // 프로필 수정 편의 메소드
+    public void updateProfile(UpdateProfileRequest request, String profileImage) {
+        this.username = request.getUsername();
+        this.introduction = request.getIntroduction();
+        this.preferredGenre = request.getPreferredGenre();
+
+        // 이미지 URL 이 null 이 아닌 경우에만 업데이트
+        if (profileImage != null) {
+            this.profileImage = profileImage;
+        }
     }
 }

--- a/src/main/java/com/bookjuk/dto/mypage/MeetingInfoDto.java
+++ b/src/main/java/com/bookjuk/dto/mypage/MeetingInfoDto.java
@@ -4,10 +4,7 @@ import com.bookjuk.domain.meeting.Meeting;
 import com.bookjuk.domain.meeting.MeetingStatus;
 import com.bookjuk.domain.participant.MeetingParticipant;
 import com.bookjuk.domain.participant.ParticipantRole;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.HashMap;
@@ -19,7 +16,7 @@ import java.util.Map;
  * 사용자가 참여한 모임 정보를 포함합니다.
  *
  */
-@Getter
+@Getter @ToString
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder

--- a/src/main/java/com/bookjuk/dto/mypage/MyPageResponse.java
+++ b/src/main/java/com/bookjuk/dto/mypage/MyPageResponse.java
@@ -20,7 +20,7 @@ import java.util.Map;
  *
  */
 @Getter
-@Builder
+@Builder @ToString
 @AllArgsConstructor
 @NoArgsConstructor
 public class MyPageResponse {

--- a/src/main/java/com/bookjuk/dto/mypage/StaticsInfoDto.java
+++ b/src/main/java/com/bookjuk/dto/mypage/StaticsInfoDto.java
@@ -1,9 +1,6 @@
 package com.bookjuk.dto.mypage;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 /**
  * 마이페이지 API 응답을 위한 통계 정보 DTO 클래스
@@ -11,7 +8,7 @@ import lombok.NoArgsConstructor;
  * 사용자의 좋아요(리뷰), 참여 모임 개수 정보를 포함합니다.
  *
  */
-@Getter
+@Getter @ToString
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/bookjuk/dto/mypage/UserInfoDto.java
+++ b/src/main/java/com/bookjuk/dto/mypage/UserInfoDto.java
@@ -1,12 +1,9 @@
 package com.bookjuk.dto.mypage;
 
 import com.bookjuk.domain.user.User;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-@Getter
+@Getter @ToString
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder

--- a/src/main/java/com/bookjuk/dto/mypage/request/UpdateProfileRequest.java
+++ b/src/main/java/com/bookjuk/dto/mypage/request/UpdateProfileRequest.java
@@ -1,0 +1,21 @@
+package com.bookjuk.dto.mypage.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+@Getter
+@ToString
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateProfileRequest {
+
+    @Size(max = 50, message = "닉네임은 50자를 초과할 수 없습니다.")
+    private String username;
+
+    private String profileImage;
+    private String preferredGenre;
+    private String introduction;
+
+}

--- a/src/main/java/com/bookjuk/dto/mypage/request/UpdateProfileRequest.java
+++ b/src/main/java/com/bookjuk/dto/mypage/request/UpdateProfileRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Size;
 import lombok.*;
 
 @Getter
+@Setter
 @ToString
 @NoArgsConstructor
 @AllArgsConstructor

--- a/src/main/java/com/bookjuk/dto/mypage/request/UpdateProfileRequest.java
+++ b/src/main/java/com/bookjuk/dto/mypage/request/UpdateProfileRequest.java
@@ -1,5 +1,6 @@
 package com.bookjuk.dto.mypage.request;
 
+import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
@@ -14,8 +15,13 @@ public class UpdateProfileRequest {
     @Size(max = 50, message = "닉네임은 50자를 초과할 수 없습니다.")
     private String username;
 
+    @Nullable
     private String profileImage;
+
+    @Nullable
     private String preferredGenre;
+
+    @Nullable
     private String introduction;
 
 }

--- a/src/main/java/com/bookjuk/dto/mypage/response/UpdateProfileResponse.java
+++ b/src/main/java/com/bookjuk/dto/mypage/response/UpdateProfileResponse.java
@@ -1,0 +1,27 @@
+package com.bookjuk.dto.mypage.response;
+
+import com.bookjuk.domain.user.User;
+import lombok.*;
+
+@Getter
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UpdateProfileResponse {
+
+    private String username;
+    private String profileImage;
+    private String introduction;
+    private String preferredGenre;
+
+    public static UpdateProfileResponse from(User user) {
+        return UpdateProfileResponse.builder()
+                .username(user.getUsername())
+                .profileImage(user.getProfileImage())
+                .introduction(user.getIntroduction())
+                .preferredGenre(user.getPreferredGenre())
+                .build();
+    }
+}

--- a/src/main/java/com/bookjuk/repository/user/UserRepository.java
+++ b/src/main/java/com/bookjuk/repository/user/UserRepository.java
@@ -23,4 +23,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
      * @return boolean - 존재하면 true, 존재하지 않으면 false
      */
     boolean existsByEmail(String email);
+
 }

--- a/src/main/java/com/bookjuk/service/MyPageService.java
+++ b/src/main/java/com/bookjuk/service/MyPageService.java
@@ -7,6 +7,7 @@ import com.bookjuk.dto.mypage.MyPageResponse;
 import com.bookjuk.dto.mypage.StaticsInfoDto;
 import com.bookjuk.dto.mypage.UserInfoDto;
 import com.bookjuk.dto.mypage.request.UpdateProfileRequest;
+import com.bookjuk.dto.mypage.response.UpdateProfileResponse;
 import com.bookjuk.exception.CustomException;
 import com.bookjuk.exception.ErrorCode;
 import com.bookjuk.repository.meeting.MeetingRepository;
@@ -19,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.awt.*;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +42,7 @@ public class MyPageService {
     /**
      * 마이페이지 진입 정보 조회(디폴트) 로직입니다.
      * @param email - 로그인한 유저가 제시한 토큰에서 파싱한 이메일 정보
-     *
+     * @return - 프론트 단에 전달할 유저 정보, 유저 모임 정보, 유저의 모임 참여, 좋아요 통계 정보를 반환합니다.
      */
     public MyPageResponse getMyPage(String email) {
 
@@ -50,8 +52,8 @@ public class MyPageService {
         // 조회된 유저 정보를 마이페이지 응답에 필요한 dto 로 변경
         UserInfoDto profile = UserInfoDto.from(user);
 
-        // 2. 유저가 참여한 미팅 정보 가져오기
-        // meeting_participant 에 유저 id로 참여 미팅 id를 리스트로 반환
+        // 2. 유저가 참여한 모임 정보 가져오기
+        // meeting_participant 에 유저 id로 참여 모임 id를 리스트로 반환
         Long userId = user.getId();
         List<MeetingInfoDto> meetings = getMeetingsByUserId(userId);
 
@@ -63,30 +65,43 @@ public class MyPageService {
 
     }
 
-    public void updateProfile(UpdateProfileRequest request, String email, MultipartFile file) {
+    /**
+     * 마이페이지 프로필 수정 로직입니다.
+     * @param request - 사용자가 수정하고자 입력한 내용 dto
+     * @param email - 로그인한 유저가 제시한 토큰에서 파싱한 이메일 정보
+     * @param file - 사용자가 업로드한 프로필 이미지
+     * @return - 프론트 단에 전달할 유저가 수정한 내용 dto
+     */
+    public UpdateProfileResponse updateProfile(UpdateProfileRequest request, String email, MultipartFile file) {
 
         // 1. 사용자 정보로 유저 정보 가져오기
-        User updatedUser = getUserByEmail(email);
+        User user = getUserByEmail(email);
 
         // 2. 프로필 이미지 업로드
+        String newImage = null;
+
         if (file != null && !file.isEmpty()) {
+
             try {
                 // 이미지 파일이 아닌 것은 스킵
-                if(file.getContentType() == null || !file.getContentType().startsWith("image/")) {
+                if (file.getContentType() == null || !file.getContentType().startsWith("image/")) {
                     throw new CustomException();
                 }
-
-
-                String profileImage = localFileService.uploadFile(file);
-                log.info("이미지 업로드 성공: {}", profileImage);
+                newImage = localFileService.uploadFile(file);
+                log.info("이미지 업로드 성공: {}", newImage);
 
             } catch (Exception e) {
-
                 log.error("이미지 업로드 실패: {}", e.getMessage());
                 throw new CustomException(ErrorCode.FILE_SIZE_EXCEEDED);
-
             }
         }
+
+        // 3. 유저 객체에 정보 수정
+        user.updateProfile(request, newImage);
+
+        // 4. 수정된 유저정보 업데이트
+        User updatedUser = userRepository.save(user);
+        return UpdateProfileResponse.from(updatedUser);
 
     }
 

--- a/src/main/java/com/bookjuk/service/MyPageService.java
+++ b/src/main/java/com/bookjuk/service/MyPageService.java
@@ -6,6 +6,7 @@ import com.bookjuk.dto.mypage.MeetingInfoDto;
 import com.bookjuk.dto.mypage.MyPageResponse;
 import com.bookjuk.dto.mypage.StaticsInfoDto;
 import com.bookjuk.dto.mypage.UserInfoDto;
+import com.bookjuk.dto.mypage.request.UpdateProfileRequest;
 import com.bookjuk.exception.CustomException;
 import com.bookjuk.exception.ErrorCode;
 import com.bookjuk.repository.meeting.MeetingRepository;
@@ -14,8 +15,11 @@ import com.bookjuk.repository.review.MeetingReviewRepository;
 import com.bookjuk.repository.user.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,6 +27,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 @Service
 @Transactional
+@Slf4j
 public class MyPageService {
 
     // 의존 객체 주입
@@ -30,6 +35,7 @@ public class MyPageService {
     private final MeetingRepository meetingRepository;
     private final MeetingReviewRepository meetingReviewRepository;
     private final MeetingParticipantRepository meetingParticipantRepository;
+    private final LocalFileService localFileService;
 
     /**
      * 마이페이지 진입 정보 조회(디폴트) 로직입니다.
@@ -54,6 +60,33 @@ public class MyPageService {
         StaticsInfoDto stats = getStatsByUserId(userId, meetingCount);
 
         return MyPageResponse.of(profile, stats, meetings);
+
+    }
+
+    public void updateProfile(UpdateProfileRequest request, String email, MultipartFile file) {
+
+        // 1. 사용자 정보로 유저 정보 가져오기
+        User updatedUser = getUserByEmail(email);
+
+        // 2. 프로필 이미지 업로드
+        if (file != null && !file.isEmpty()) {
+            try {
+                // 이미지 파일이 아닌 것은 스킵
+                if(file.getContentType() == null || !file.getContentType().startsWith("image/")) {
+                    throw new CustomException();
+                }
+
+
+                String profileImage = localFileService.uploadFile(file);
+                log.info("이미지 업로드 성공: {}", profileImage);
+
+            } catch (Exception e) {
+
+                log.error("이미지 업로드 실패: {}", e.getMessage());
+                throw new CustomException(ErrorCode.FILE_SIZE_EXCEEDED);
+
+            }
+        }
 
     }
 
@@ -96,4 +129,5 @@ public class MyPageService {
         Long reviewCount = meetingReviewRepository.countReviewByUserId(id);
         return StaticsInfoDto.of(reviewCount, count);
     }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:

--- a/src/test/java/com/bookjuk/controller/ReviewControllerTest.java
+++ b/src/test/java/com/bookjuk/controller/ReviewControllerTest.java
@@ -214,8 +214,26 @@ class ReviewControllerTest {
     */
 
         User u5 = userRepository.findByEmail("abc@naver.com").orElseThrow();
+        User u6 = User.builder()
+                .username("치이카와")
+                .email("abc123dd@naver.com")
+                .password("abc123")
+                .build();
+
+        User u7 = User.builder()
+                .username("쿠리링")
+                .email("abc123@naver.com")
+                .password("abc123")
+                .build();
+
+        userRepository.saveAllAndFlush(
+                List.of(u6, u7)
+        );
+        /*
         User u6 = userRepository.findByEmail("abc123@dddaum.net").orElseThrow();
         User u7 = userRepository.findByEmail("abc123@dddammum.net").orElseThrow();
+
+
 
 
         m1 = Meeting.builder()
@@ -262,9 +280,27 @@ class ReviewControllerTest {
                 List.of(mp1, mp2, mp3)
         );
 
+        MeetingReview rv1 = MeetingReview.builder()
+                .meeting(m1)
+                .reviewer(u6)
+                .reviewee(u5)
+                .build();
+
+        MeetingReview rv2 = MeetingReview.builder()
+                .meeting(m1)
+                .reviewer(u7)
+                .reviewee(u5)
+                .build();
+
+        meetingReviewRepository.saveAllAndFlush(
+                List.of(rv1, rv2)
+        );
+
 
         em.flush();
         em.clear();
+
+         */
       
     }
 

--- a/src/test/java/com/bookjuk/repository/meeting/MeetingRepositoryTest.java
+++ b/src/test/java/com/bookjuk/repository/meeting/MeetingRepositoryTest.java
@@ -220,7 +220,7 @@ class MeetingRepositoryTest {
 
         // when (더티 체킹)
         String updatedTitle = meetings.get(0).getTitle() + "-수정";
-        meetings.get(0).changeTitle(updatedTitle);
+        //meetings.get(0).changeTitle(updatedTitle);
         em.flush();
         em.clear();
 

--- a/src/test/java/com/bookjuk/service/MyPageServiceTest.java
+++ b/src/test/java/com/bookjuk/service/MyPageServiceTest.java
@@ -1,0 +1,218 @@
+package com.bookjuk.service;
+
+import com.bookjuk.domain.meeting.Meeting;
+import com.bookjuk.domain.meeting.MeetingStatus;
+import com.bookjuk.domain.participant.MeetingParticipant;
+import com.bookjuk.domain.participant.ParticipantRole;
+import com.bookjuk.domain.participant.ParticipantStatus;
+import com.bookjuk.domain.review.MeetingReview;
+import com.bookjuk.domain.user.User;
+import com.bookjuk.dto.mypage.MyPageResponse;
+import com.bookjuk.dto.review.ReviewResponse;
+import com.bookjuk.repository.meeting.MeetingRepository;
+import com.bookjuk.repository.participant.MeetingParticipantRepository;
+import com.bookjuk.repository.review.MeetingReviewRepository;
+import com.bookjuk.repository.user.UserRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Rollback;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+@Rollback(value = false)
+class MyPageServiceTest {
+    @Autowired
+    MeetingRepository meetingRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Autowired
+    MeetingParticipantRepository meetingParticipantRepository;
+
+    @Autowired
+    MeetingReviewRepository meetingReviewRepository;
+
+    @Autowired
+    MyPageService myPageService;
+
+    @Autowired
+    EntityManager em;
+
+    private User u1, u2, u3, u4;
+    private Meeting m1, m2, m3;
+    private MeetingParticipant mp1, mp2, mp3, mp4, mp5, mp6;
+
+    private List<MeetingParticipant> meetingParticipants;
+
+    @BeforeEach
+    void insertBulk() {
+        meetingParticipantRepository.deleteAll();
+        meetingRepository.deleteAll();
+        userRepository.deleteAll();
+        // 유저정보 만들기 (임시 테스트용)
+        u1 = User.builder()
+                .username("치이카와")
+                .email("abc123@naver.com")
+                .password("abc123")
+                .build();
+        u2 = User.builder()
+                .username("하치와레")
+                .email("abc123@google.com")
+                .password("abc123d")
+                .build();
+        u3 = User.builder()
+                .username("우사기")
+                .email("abc123@daum.net")
+                .password("abcd123")
+                .build();
+
+        u4 = User.builder()
+                .username("주댕치")
+                .email("abc123ddd@daum.net")
+                .password("abcddfdf123")
+                .build();
+
+        List<User> users = userRepository.saveAllAndFlush(
+                List.of(u1, u2, u3, u4)
+        );
+
+        // 모임정보 만들기
+        m1 = Meeting.builder()
+                .host(u1)
+                .title("먼작귀친구들")
+                .description("책 읽으며 놀아요.")
+                .imageUrl("https://example.com/image.jpg")
+                .bookTitle("먼작귀")
+                .bookAuthor("나가노작가")
+                .genre("동화")
+                .meetingTime(LocalDateTime.of(2025, 8, 20, 19, 0))
+                .region("경기도")
+                .city("안산시")
+                .district("단원구")
+                .maxParticipants(6)
+                .meetingStatus(MeetingStatus.COMPLETED)
+                .build();
+        m2 = Meeting.builder()
+                .host(u2)
+                .title("가나디친구들")
+                .description("책을 읽어봅시다.")
+                .imageUrl("https://example.com/image2.jpg")
+                .bookTitle("가나디")
+                .bookAuthor("짤쓸사람")
+                .genre("동화")
+                .meetingTime(LocalDateTime.of(2025, 8, 18, 19, 0))
+                .region("경기도")
+                .city("안양시")
+                .district("단원구")
+                .maxParticipants(8)
+                .meetingStatus(MeetingStatus.RECRUITING)
+                .build();
+        m3 = Meeting.builder()
+                .host(u2)
+                .title("초원의 왕")
+                .description("왕이 되어봅시다.")
+                .imageUrl("https://example.com/image3.jpg")
+                .bookTitle("라이온킹")
+                .bookAuthor("무파사")
+                .genre("동화")
+                .meetingTime(LocalDateTime.of(2025, 8, 21, 19, 0))
+                .region("경기도")
+                .city("구리시")
+                .district("단원구")
+                .maxParticipants(4)
+                .meetingStatus(MeetingStatus.RECRUITING)
+                .build();
+
+        List<Meeting> meetings = meetingRepository.saveAllAndFlush(
+                List.of(m1, m2, m3)
+        );
+
+        // 참가자 정보 만들기
+        mp1 = MeetingParticipant.builder()
+                .participant(u1)
+                .meeting(m1)
+                .role(ParticipantRole.HOST)
+                .status(ParticipantStatus.APPROVED)
+                .build();
+        mp2 = MeetingParticipant.builder()
+                .participant(u2)
+                .meeting(m1)
+                .role(ParticipantRole.PARTICIPANT)
+                .status(ParticipantStatus.APPROVED)
+                .build();
+        mp3 = MeetingParticipant.builder()
+                .participant(u3)
+                .meeting(m1)
+                .role(ParticipantRole.PARTICIPANT)
+                .status(ParticipantStatus.PENDING)
+                .build();
+        mp4 = MeetingParticipant.builder()
+                .participant(u1)
+                .meeting(m2)
+                .role(ParticipantRole.PARTICIPANT)
+                .status(ParticipantStatus.PENDING)
+                .build();
+        mp5 = MeetingParticipant.builder()
+                .participant(u2)
+                .meeting(m2)
+                .role(ParticipantRole.HOST)
+                .status(ParticipantStatus.APPROVED)
+                .build();
+        mp6 = MeetingParticipant.builder()
+                .participant(u2)
+                .meeting(m3)
+                .role(ParticipantRole.HOST)
+                .status(ParticipantStatus.APPROVED)
+                .build();
+
+
+        meetingParticipants = meetingParticipantRepository.saveAllAndFlush(
+                List.of(mp1, mp2, mp3, mp4, mp5, mp6)
+        );
+
+        // 좋아요 정보 생성
+        MeetingReview rw1 = MeetingReview.builder()
+                .meeting(m1)
+                .reviewer(u1)
+                .reviewee(u2)
+                .build();
+
+        MeetingReview rw2 = MeetingReview.builder()
+                .meeting(m1)
+                .reviewer(u1)
+                .reviewee(u3)
+                .build();
+
+        meetingReviewRepository.save(rw1);
+        meetingReviewRepository.save(rw2);
+
+        em.flush();
+        em.clear();
+    }
+
+    // ========== 마이페이지 정보 조회 ==========
+    @Test
+    @DisplayName("마이페이지에서 내 정보를 확인한다.")
+    void getMyPage() {
+        // given
+        String email = "dsfsdfs@email.com";
+
+        // when
+        MyPageResponse response = myPageService.getMyPage(email);
+
+        // then
+        System.out.println("response = " + response);
+    }
+
+}

--- a/src/test/java/com/bookjuk/service/MyPageServiceTest.java
+++ b/src/test/java/com/bookjuk/service/MyPageServiceTest.java
@@ -8,6 +8,8 @@ import com.bookjuk.domain.participant.ParticipantStatus;
 import com.bookjuk.domain.review.MeetingReview;
 import com.bookjuk.domain.user.User;
 import com.bookjuk.dto.mypage.MyPageResponse;
+import com.bookjuk.dto.mypage.request.UpdateProfileRequest;
+import com.bookjuk.dto.mypage.response.UpdateProfileResponse;
 import com.bookjuk.dto.review.ReviewResponse;
 import com.bookjuk.repository.meeting.MeetingRepository;
 import com.bookjuk.repository.participant.MeetingParticipantRepository;
@@ -24,6 +26,7 @@ import org.springframework.test.annotation.Rollback;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -55,6 +58,7 @@ class MyPageServiceTest {
 
     private List<MeetingParticipant> meetingParticipants;
 
+    /*
     @BeforeEach
     void insertBulk() {
         meetingParticipantRepository.deleteAll();
@@ -200,6 +204,7 @@ class MyPageServiceTest {
         em.flush();
         em.clear();
     }
+    */
 
     // ========== 마이페이지 정보 조회 ==========
     @Test
@@ -215,4 +220,23 @@ class MyPageServiceTest {
         System.out.println("response = " + response);
     }
 
+    // ========== 마이페이지 정보 수정 ==========
+    @Test
+    @DisplayName("마이페이지에서 내 정보를 수정한다.")
+    void updateInfo() {
+        // given
+        String email = "abc123@naver.com";
+        User user = userRepository.findByEmail(email).orElseThrow();
+        UpdateProfileRequest req = UpdateProfileRequest.builder()
+                .username(user.getUsername())
+                .preferredGenre("소설")
+                .introduction("안녕하세요")
+                .build();
+
+        // when
+        UpdateProfileResponse response = myPageService.updateProfile(req, email, null);
+        // then
+        System.out.println("response = " + response);
+
+    }
 }


### PR DESCRIPTION
## 개요
- 마이페이지 기능 구현에 필요한 api controller를 작성하고 테스트를 완료했습니다.

## 변경 사항
- MyPageController 클래스 생성
- User 객체 내부에 프로필 정보를 업데이트 할 수 있는 updateProfile 수정 편의 메소드 생성
- 프론트엔드로부터 수정받은 정보를 서비스로 요청하기 위한 UpdateProfileRequest dto 생성
- 수정 작업 db update 완료 후 프론트엔드에게 보낼 응답 UpdateProfileResponse dto 생성
- MyPageService 클래스에 수정 기능 비즈니스 로직 추가

## 테스트 방법
postman, junit 테스트 도구 활용하여 테스트 했습니다.   
아래는 테스트 화면입니다.

마이페이지 정보 조회 
<img width="698" height="854" alt="마이페이지pr용테스트이미지1" src="https://github.com/user-attachments/assets/cdbd6296-92c2-4160-9c84-11ca98e88cef" />   

<img width="754" height="796" alt="마이페이지pr용테스트이미지2" src="https://github.com/user-attachments/assets/5e38d64c-63d4-4c10-8876-c5b6b5f45586" />

마이페이지 프로필 정보 수정   
<img width="1038" height="696" alt="image" src="https://github.com/user-attachments/assets/e06c9593-f811-4799-946e-c6c3f701e1e8" />   

<img width="1173" height="85" alt="image" src="https://github.com/user-attachments/assets/bb7140ab-6dd2-4de5-a1d3-b665d3eb1d6f" />




## 관련 이슈
- Resolves #68 
- Resolves #47 