### PR TITLE
style: #94 메인 페이지 모임 카드 장소 표기 개선, 상세 페이지와 스타일 통일

### DIFF
--- a/src/main/resources/static/css/main-page.css
+++ b/src/main/resources/static/css/main-page.css
@@ -1,9 +1,3 @@
-/* =========================
-   Book Club Cafe Style CSS (updated)
-   - 필터 여백 확대
-   - 검색/시작하기 버튼 네모형으로 통일 (말풍선 제거)
-   ========================= */
-
 /* ---------- 변수(팔레트/타이포/공통) ---------- */
 :root {
   /* palette */
@@ -32,24 +26,29 @@
 }
 
 /* ---------- 초기화 ---------- */
-* { box-sizing: border-box; margin: 0; padding: 0; }
+* {
+  box-sizing:border-box;
+  margin: 0;
+  padding: 0;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+}
 html, body { height: 100%; }
 body {
   color: var(--ink);
   line-height: 1.6;
-  font-family: var(--sans);
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 
   /* 종이 질감 배경 */
-  background-color: var(--paper);
+  background-color: #f8f8f8;
   background-image:
-    radial-gradient(rgba(0,0,0,0.018) 1px, transparent 1px),
-    radial-gradient(rgba(0,0,0,0.012) 1px, transparent 1px);
+          radial-gradient(rgba(0,0,0,0.018) 1px, transparent 1px),
+          radial-gradient(rgba(0,0,0,0.012) 1px, transparent 1px);
   background-position: 0 0, 8px 8px;
   background-size: 16px 16px;
 }
 
 /* 공통 카드/그림자 */
-.card, .filter-container, .meeting-card, .hero-section, .pagination button, .dropdown-menu, .empty-state, .search-btn, .start-btn {
+.card, .filter-container, .meeting-card, .hero-section, .pagination button, .dropdown-menu, .empty-state, .search-btn {
   border-radius: var(--radius);
   box-shadow: 0 6px 18px var(--shadow-1);
 }
@@ -62,36 +61,69 @@ body {
 
 /* ---------- Header ---------- */
 .header {
-  display: flex; justify-content: space-between; align-items: center;
-  padding: 18px 50px;
-  background: linear-gradient(180deg, var(--paper-2), var(--paper));
-  border-bottom: 1px solid var(--line);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 20px 50px;
+  background-color: #fff;
+  border-bottom: 1px solid #eee;
 }
 .logo {
-  font-family: var(--serif);
-  letter-spacing: 1px;
-  font-size: 28px; font-weight: 800;
-  color: var(--forest);
-  position: relative;
+  font-size: 24px;
+  font-weight: bold;
+  color: #8b7355;
+  cursor: pointer;
 }
-.logo::before {
-  content: "📘";
-  margin-right: 8px;
-  font-size: 22px;
+.nav {
+  display: flex;
+  align-items: center;
+  gap: 20px;
 }
 .nav a {
-  text-decoration: none; color: var(--cafe); font-weight: 600; margin-left: 18px;
-  padding: 8px 12px; border-radius: var(--radius-sm);
-  transition: background .25s ease, color .25s ease;
+  text-decoration: none;
+  color: #555;
+  font-weight: 500;
+  padding: 8px 15px;
+  border-radius: 5px;
+  transition: background-color 0.3s;
 }
-.nav a:hover { background: rgba(200,166,106,0.12); color: var(--ink); }
+.nav a:hover { background-color: #f0f0f0; }
+
+.nav .create-meeting-btn {
+  background-color: #5d5dff;
+  color: #fff;
+  font-weight: 500;
+  border: none;
+  border-radius: 6px;
+  padding: 8px 16px;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+.nav .create-meeting-btn:hover {
+  background-color: rgb(240, 240, 240);
+}
+.nav .logout-btn {
+  text-decoration: none;
+  background-color: #ffffff;
+  font-size: 16px;
+  color: #555;
+  font-weight: 500;
+  padding: 8px 15px;
+  border-radius: 5px;
+  border-color: transparent;
+  cursor: pointer;
+  transition: background-color 0.3s;
+}
+.nav .logout-btn:hover {
+  background-color: #f0f0f0;
+}
 
 /* ---------- Main ---------- */
 .main-content { max-width: 1200px; margin: 0 auto; padding: 30px; }
 
 /* ---------- Hero(메인 배너) ---------- */
 .hero-section {
-  text-align: center; padding: 72px 20px;
+  text-align: center; padding: 60px 20px;
   background: linear-gradient(180deg, var(--paper-2) 0%, #fff 80%);
   border: 1px solid var(--line);
   position: relative;
@@ -111,19 +143,19 @@ body {
 }
 
 /* 버튼 공통 */
-.btn, .start-btn, .search-btn {
+.btn, .search-btn {
   position: relative; border: none; cursor: pointer;
   padding: 14px 22px 16px; font-size: 16px; font-weight: 700;
-  color: #fff; background: var(--forest);
+  color: #fff; background: #8b7355;
   border-radius: var(--radius-sm);
   transition: transform .1s ease, box-shadow .2s ease, background .2s ease;
 }
-.btn:hover, .start-btn:hover, .search-btn:hover {
+.btn:hover, .search-btn:hover {
   transform: translateY(-1px);
   box-shadow: 0 10px 20px var(--shadow-2);
   background: var(--forest-2);
 }
-.btn:active, .start-btn:active, .search-btn:active { transform: translateY(0); }
+.btn:active, .search-btn:active { transform: translateY(0); }
 /* 책갈피 하단 삼각 홈은 bookmark 변형에서만 사용 */
 .btn.bookmark::after {
   content:""; position:absolute; bottom:-8px; left: 18px;
@@ -199,7 +231,7 @@ body {
   gap: 8px;
   justify-content: center;
   border-radius: var(--radius-sm); /* 살짝 둥근 네모 */
-  background: var(--forest);
+  background: #8b7355;
   color: #fff;
   padding: 12px 20px;
   border: none;
@@ -208,7 +240,7 @@ body {
   transition: transform .1s ease, box-shadow .2s ease, background .2s ease;
   position: relative;
 }
-.search-btn:hover { transform: translateY(-1px); box-shadow: 0 8px 16px var(--shadow-2); background: var(--forest-2); }
+.search-btn:hover { transform: translateY(-1px); box-shadow: 0 8px 16px var(--shadow-2); background: #75634a; }
 .search-btn:active { transform: translateY(0); }
 .search-btn::after { display: none; } /* 말풍선 제거 */
 
@@ -252,20 +284,23 @@ body {
 .meeting-card:hover .card-image::after { transform: perspective(600px) rotateY(-6deg); opacity: 1; }
 
 .status-tag, .genre-tag {
-  position: absolute; top: 14px; padding: 6px 10px;
+  position: absolute; top: 14px; padding: 8px 15px;
   border-radius: 999px; font-size: 12px; color: #fff; font-weight: 800;
   box-shadow: 0 6px 12px var(--shadow-1);
 }
 .status-tag { left: 14px; background: var(--forest); }
-.status-tag.ongoing { background: var(--forest); }
+.status-tag.ongoing { background: #5d5dff; }
 .status-tag.closed  { background: #9a8c7d; }
 .status-tag.cancelled { background: var(--orange); }
-.genre-tag { right: 14px; background: var(--cafe); }
+.genre-tag { right: 14px; background: rgba(0, 0, 0, 0.7); }
 
 .card-content { padding: 18px; background: #fff; }
 .card-title {
-  font-family: var(--serif);
-  font-size: 20px; font-weight: 800; margin-bottom: 8px; color: var(--ink);
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  font-size: 22px;
+  font-weight: bold;
+  margin-bottom: 8px;
+  color: #333;
 }
 .card-info, .card-date, .card-location, .card-author {
   display: flex; align-items: center; color: #5b4b3b; font-size: 14px; margin-bottom: 5px;
@@ -343,38 +378,16 @@ body {
   color: var(--ink);
 }
 .pagination button:hover:not(:disabled) {
-  background: #f6fff6; border-color: #b4d3c9; color: #2F5D50;
+  border: 1px solid var(--line);
   transform: translateY(-2px); box-shadow: 0 6px 14px var(--shadow-1);
 }
 .pagination button:disabled {
   background: #f3eee5; color: #a4917e; border-color: #e6d9c8; cursor: not-allowed; box-shadow: none;
 }
 .pagination .page-btn.active {
-  background: var(--forest); color: #fff; border-color: var(--forest); font-weight: 800;
-  box-shadow: 0 8px 18px rgba(47,93,80,0.3);
+  background: #8b7355; color: #fff; border-color: #8b7355; font-weight: 800;
 }
 .pagination .gap { color: #8b7a68; padding: 0 6px; font-size: 16px; }
-
-/* ---------- 시작하기 버튼 - 네모형 (말풍선 제거) ---------- */
-.start-btn {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  border-radius: var(--radius-sm); /* 살짝 둥근 네모 */
-  background: var(--forest);
-  color: #fff;
-  padding: 14px 24px;
-  border: none;
-  cursor: pointer;
-  font-weight: 700;
-  font-size: 16px;
-  transition: transform .1s ease, box-shadow .2s ease, background .2s ease;
-  position: relative;
-}
-.start-btn:hover { transform: translateY(-1px); box-shadow: 0 10px 20px var(--shadow-2); background: var(--forest-2); }
-.start-btn:active { transform: translateY(0); }
-.start-btn::after { display: none; } /* 말풍선 제거 */
 
 /* ---------- 애니메이션 ---------- */
 @keyframes fadeIn { from { opacity: 0; transform: translateY(6px);} to { opacity: 1; transform: translateY(0);} }

--- a/src/main/resources/static/js/main-page.js
+++ b/src/main/resources/static/js/main-page.js
@@ -232,10 +232,10 @@ function updateNavigationByLoginStatus() {
     if (userNav) {
       userNav.style.display = 'flex';
       userNav.innerHTML = `
-        <span style="color: #333; font-weight: 500;">안녕하세요, ${user.username || user.name || '사용자'}님!</span>
-        <a href="/mypage" style="color: #007bff; text-decoration: none;">마이페이지</a>
-        <a href="/createMeeting" style="color: #28a745; text-decoration: none; font-weight: bold;">모임 만들기</a>
-        <button onclick="logout()" style="background: none; border: 1px solid #dc3545; color: #dc3545; padding: 5px 10px; border-radius: 4px; cursor: pointer;">로그아웃</button>
+        <a href="/mypage" class="mypage-link">마이페이지</a>
+        <a href="/createMeeting" class="create-meeting-btn">모임 만들기</a>
+        <span style="color: #555; margin-right: 10px;">안녕하세요, ${user.username || user.name || '사용자'}님!</span>
+        <button onclick="logout()" class="logout-btn">로그아웃</button>
       `;
     }
   } else {
@@ -259,7 +259,7 @@ function logout() {
 // ===== 유틸: 상태/텍스트/클래스 매핑 =====
 function mapStatusToTextKorean(status) {
   switch (status) {
-    case 'RECRUITING': return '모집중';
+    case 'RECRUITING': return '모집 중';
     case 'COMPLETED':  return '종료';
     case 'CANCELLED':  return '취소';
     default:           return status || '';

--- a/src/main/resources/static/js/main-page.js
+++ b/src/main/resources/static/js/main-page.js
@@ -284,6 +284,7 @@ function formatDateTime(dtStr) {
   const mm = String(d.getMinutes()).padStart(2,'0');
   return `${y}.${m}.${day} ${hh}:${mm}`;
 }
+// 브라우저 태그 실행 방지, XSS(교차 사이트 스크립팅) 공격 방지
 function escapeHtml(str) {
   if (typeof str !== 'string') return str ?? '';
   return str.replaceAll('&','&amp;').replaceAll('<','&lt;').replaceAll('>','&gt;').replaceAll('"','&quot;').replaceAll("'",'&#39;');
@@ -386,7 +387,10 @@ function renderMeetings(data) {
         const title = it.title ?? '';
         const desc = it.description ?? '';
         const when   = it.meetingTime ?? '';
-        const city = it.city ?? it.region ?? '';
+        const region = it.region ?? '';
+        const city = it.city ?? '';
+        // 지역 표기: region과 city가 둘 다 있으면 "서울특별시 강남구"
+        const fullLocation = region && city ? `${region} ${city}` : (region || city || '');
         const curr   = it.currentParticipants ?? it.currParticipants ?? it.participantsCount ?? 0;
         const max = it.maxParticipants ?? it.capacity ?? it.limit ?? 0;
         const host = (it.host && (it.host.username || it.host.name)) || it.hostUsername || '';
@@ -407,7 +411,10 @@ function renderMeetings(data) {
             <h3 class="card-title">${escapeHtml(title)}</h3>
             <p class="card-info"><span>📖</span><span>${escapeHtml(desc)}</span></p>
             <p class="card-date"><span>🗓️</span><span>${formatDateTime(when)}</span></p>
-            <p class="card-location"><span>📍</span><span>${escapeHtml(city)} · ${curr}/${max}명</span></p>
+            <p class="card-location">
+                <span>📍</span>
+                <span>${escapeHtml(fullLocation)} · ${curr}/${max}명</span>
+            </p>
             <p class="card-author">
               <span class="author">
                 ${hostProfile

--- a/src/main/resources/templates/main-page.html
+++ b/src/main/resources/templates/main-page.html
@@ -19,7 +19,6 @@
     <section class="hero-section">
         <h2 class="hero-title">책과 사람이 만나는 곳</h2>
         <p class="hero-subtitle">따뜻한 오프라인 독서모임에서 새로운 인연과 깊은 이야기를 나누세요</p>
-        <button class="start-btn">지금 시작하기</button>
     </section>
     <section class="filter-section">
         <div class="filter-container">


### PR DESCRIPTION
## 개요
- 메인 페이지의 모임 카드의 장소 표현 방식을 더욱 자세하게 표현할 수 있도록 변경했습니다.
- 모임 상세 페이지에 맞춰 메인 페이지의 css를 변경했습니다.

## 변경 사항
1. 메인 페이지의 타이틀 부분에 있던 '시작하기' 버튼을 불필요하다고 판단하여 삭제했습니다.

2. 모임 카드의 장소 표현 방식을 '강남구'에서 '서울특별시 강남구'의 형태로 변경했습니다.

3. 모임 상세 페이지와 유사하도록 스타일을 변경하기 위해서 main-page.html, main-page.css, main-page.js를 변경했습니다.


## 테스트 방법
- 로컬 환경에서 톰캣을 실행하고, 브라우저에서 버튼 클릭을 통해 수동 테스트를 진행했습니다.
1. 모임 카드의 장소 표현 방식 사진
<img width="396" height="446" alt="image" src="https://github.com/user-attachments/assets/f4ed40ea-8779-4a72-9b1e-1d7b3a4aee08" />
---

2. 스타일 변경 후 사진 1
<img width="1914" height="899" alt="image" src="https://github.com/user-attachments/assets/8badc5ec-e3d5-43fb-88b0-7e47da4bf340" />
---

3. 스타일 변경 후 사진 2
<img width="1914" height="771" alt="image" src="https://github.com/user-attachments/assets/f615e89b-185a-4217-b57d-1e65e0733f45" />
---

4. 스타일 변경 전 사진 1
<img width="1917" height="883" alt="image" src="https://github.com/user-attachments/assets/9bb3160a-5b7d-4963-a0bd-e33b6f3510d1" />

5. 스타일 변경 전 사진 2
<img width="1918" height="685" alt="image" src="https://github.com/user-attachments/assets/2e139d04-d6d7-4909-b7d7-8a00157ec04a" />


## 관련 이슈
- Resolves #94 
