### PR TITLE
fix : 로그인 성공 후 리다이렉팅(메인 페이지) 경로 수정 / 사용자가 로그인 상태일 경우 로그인 폼 숨김 및 메인 페이지로 리다이렉팅

### DIFF
--- a/src/main/resources/static/js/auth.js
+++ b/src/main/resources/static/js/auth.js
@@ -102,6 +102,27 @@ function showToast(message, type = 'success') {
     setTimeout(removeToast, 5000);
 }
 
+// ==================================================
+// 인증 게이트키핑 로직 (로그인 상태면 로그인 페이지 접속 시 메인 페이지로 자동 이동)
+// 페이지가 로드되자마자 로그인 상태를 확인합니다.
+// ==================================================
+(function () {
+    if (auth.isLoggedIn()) {
+        // 로그인 폼/회원가입 폼을 숨겨서 깜빡임을 방지
+        const loginForm = document.getElementById('login-form');
+        const signupForm = document.getElementById('signup-form');
+        if(loginForm) loginForm.classList.add('hidden');
+        if(signupForm) signupForm.classList.add('hidden');
+
+        // 사용자에게 알림을 보여주고 메인 페이지로 리다이렉트
+        showToast('이미 로그인된 상태입니다. 메인 페이지로 이동합니다.', 'success');
+        setTimeout(() => {
+            window.location.href = '/'; // 메인 페이지('/')로 이동
+        }, 1500); // 1.5초 후에 이동
+    }
+})();
+// ==================================================
+
 // DOM 요소 가져오기
 const loginForm = document.getElementById('login-form');
 const signupForm = document.getElementById('signup-form');
@@ -233,7 +254,7 @@ loginForm.addEventListener('submit', async (event) => {
     try {
         await auth.login(email, password);
         showToast('로그인 성공! 모임 목록으로 이동합니다.', 'success');
-        setTimeout(() => window.location.href = '/meetings/list', 1000); // 1초 후 모임 목록으로
+        setTimeout(() => window.location.href = '/', 1000); // 1초 후 모임 목록(메인 페이지)으로
     } catch (error) {
         showToast(error.detail || '로그인에 실패했습니다.', 'error');
     }


### PR DESCRIPTION
## 개요
사용자 경험(UX) 향상을 위해 auth.js의 페이지 이동 관련 로직을 개선합니다. 기존 리다이렉션 경로의 오류(메인페이지로 이동)를 수정하고, 이미 로그인한 사용자가 인증 페이지(로그인/회원가입)에 접근하는 경우 메인 페이지로 자동 이동시키는 기능을 추가합니다.

## 변경 사항
-   **로그인 상태에서 인증 페이지 접근 시 메인으로 리다이렉트:**
    -   [ ] 사용자가 로그인 상태일 경우, 메인 페이지(`/`)로 리다이렉트하는 로직을 추가합니다. (`window.location.href` 사용)

-   **기존 리다이렉션 경로 수정:**
    -   [ ] `auth.js` 파일 내에서 로그인 성공 후 바뀐 메인페이지 이동 경로로 수정합니다.


## 테스트 (게이트 키핑 코드 작동 확인)
- 게이트 키핑 코드 추가 전
<img width="1900" height="517" alt="로그인상태에서 로그인폼이 보임" src="https://github.com/user-attachments/assets/5eca0e0d-cf82-46c1-9796-d1d26a8e9318" />

- 게이트 키핑 코드 추가 후
<img width="1904" height="466" alt="게이트키핑로직 추가 후 로그인 폼 숨김" src="https://github.com/user-attachments/assets/674870a7-d36b-48d5-ba95-6e4bf968533e" />


## 관련 이슈
- #98  
